### PR TITLE
Move doc deps to a requirements.txt file, for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx >= 2.1
+sphinx-autodoc-typehints
+sphinx-rtd-theme
+.

--- a/tox.ini
+++ b/tox.ini
@@ -51,9 +51,7 @@ markers =
 description = invoke sphinx-build to build the HTML docs
 basepython = python3
 deps =
-    sphinx >= 2.1
-    sphinx-autodoc-typehints
-    sphinx-rtd-theme
+    -rdocs/requirements.txt
 commands =
     sphinx-build -a -E -c docs -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows readthedocs.io to build the docs

### Why should this Pull Request be merged?

Publish docs

### What testing has been done?

Ran `tox -e docs`, and pointed readthedocs at my fork to check that *it* works, too
