### PR TITLE
Add Publish-to-PyPI workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,32 @@
+name: Publish Package to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-publish:
+    if: github.repository == 'ni/nisystemlink-clients-python'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install setuptools and other tools
+        run: python3 -m pip install setuptools wheel twine
+
+      - name: Build packages
+        run: python3 setup.py bdist_wheel
+
+      - name: Publish distribution to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Automate publishing to PyPI

### Why should this Pull Request be merged?

Less manual work

### What testing has been done?

Used an equivalent workflow to publish a test python package to the PyPI Test server.