### PR TITLE
Enable cloud integration testing for PRs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,4 +26,4 @@ jobs:
         pip install tox tox-gh-actions
     - name: Run tox
       run: |
-        tox
+        tox -- --cloud-api-key ${{ secrets.CLOUD_API_KEY }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Passes a cloud API key added as a repo secret to tox.

### Why should this Pull Request be merged?

Enables more automated testing surface for PR validation.

### What testing has been done?

Ran tox locally with the same API key for py38.
