### PR TITLE
Update README documentation and package links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ Interface) for `SystemLink <https://ni.com/systemlink>`_ that uses HTTP to
 interact with a SystemLink Server. The package is implemented in Python. NI
 created and supports this package.
 
+.. image:: https://badge.fury.io/py/nisystemlink-clients.svg
+    :target: https://badge.fury.io/py/nisystemlink-clients
+
 Requirements
 ============
 **nisystemlink-clients** has the following requirements:
@@ -40,7 +43,7 @@ To install **nisystemlink-clients**, use one of the following methods:
 
 Usage
 =====
-Refer to the `documentation <https://nisystemlink-clients-python.readthedocs.io/en/latest/>`_
+Refer to the `documentation <https://python-docs.systemlink.io>`_
 for detailed information on how to use **nisystemlink-clients**.
 
 .. _support_section:
@@ -59,7 +62,7 @@ To report a bug or submit a feature request, please use the
 Documentation
 =============
 To view the documentation, visit the
-`systemlink.clients Documentation Page <https://nisystemlink-clients-python.readthedocs.io>`_.
+`systemlink.clients Documentation Page <https://python-docs.systemlink.io>`_.
 
 License
 =======


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates documentation links to point to our custom domain https://python-docs.systemlink.io and adds a badge pointing to the PyPI package.

### Why should this Pull Request be merged?

Avoids the redirect from the old readthedocs.io page to the new one. Makes it easier to find which package and version is available.

### What testing has been done?

Viewed the rendered page: https://github.com/ni/nisystemlink-clients-python/tree/users/pspangle/readme-links
