### PR TITLE
Fix running SystemLink Server integration tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,8 +56,8 @@ def server_config(pytestconfig):
     if settings:
         return core.HttpConfiguration(
             settings.get("url", "http://localhost"),
-            settings.get("user", "admin"),
-            settings.get("password", "admin"),
+            username=settings.get("user", "admin"),
+            password=settings.get("password", "admin"),
         )
     try:
         return core.HttpConfigurationManager.get_configuration(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes the parameters passed by conftest.py for the --web-server-user and --web-server-password parameters.

### Why should this Pull Request be merged?

Running the SystemLink Server integration tests with a non-default username or password currently fails.

### What testing has been done?

Ran `tox -e py38 -- --web-server-url <server> --web-server-user <user> --web-server-password <password>`
