### PR TITLE
Ensure nisystemlink-clients-python treats systemlink as an implicit namespace package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
         pip install tox tox-gh-actions
     - name: Run tox
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install tox tox-gh-actions
     - name: Run tox
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /.tox
 /.venv
 __pycache__/
+.mypy_cache/
+build/
+dist/

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 mypy_path=systemlink/stubs
 files=systemlink,tests
 warn_unused_configs=True
+namespace_packages=True
 
 [mypy-systemlink.*]
 disallow_untyped_calls=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools>=40.1.0",
+    "wheel"
+]

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,8 @@ setup(
         "events",
         'httpx;python_version>="3.6"',
         'requests;python_version<"3.6"',
-        "setuptools>=40.1.0",
         "typing-extensions",
     ],
-    setup_requires=["setuptools>=40.1.0"],
     tests_require=["pytest", "pytest-asyncio", "mypy"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "events",
         'httpx;python_version>="3.6"',
         'requests;python_version<"3.6"',
+        "setuptools>=40.1.0",
         "typing-extensions",
     ],
     setup_requires=["setuptools>=40.1.0"],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_namespace_packages, find_packages, setup  # type: ignore
 from setuptools.command.test import test as TestCommand  # type: ignore
 
 
@@ -15,6 +15,10 @@ class PyTest(TestCommand):
 
 
 pypi_name = "nisystemlink-clients"
+
+packages = find_namespace_packages(include=["systemlink.*"]) + find_packages(
+    exclude=["systemlink", "examples", "tests"]
+)
 
 
 def _get_version(name):
@@ -46,7 +50,7 @@ setup(
     maintainer_email="paul.spangler@ni.com, alex.weaver@ni.com",
     keywords=["nisystemlink", "systemlink"],
     license="MIT",
-    packages=find_packages(exclude=["examples", "tests"]),
+    packages=packages,
     install_requires=[
         'aenum;python_version<"3.6"',
         "events",
@@ -54,6 +58,7 @@ setup(
         'requests;python_version<"3.6"',
         "typing-extensions",
     ],
+    setup_requires=["setuptools>=40.1.0"],
     tests_require=["pytest", "pytest-asyncio", "mypy"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@
 
 [tox]
 envlist = py3,py35,py36,py37,py38
+requires =
+    setuptools >= 40.1.0
 
 [testenv]
 deps =


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`systemlink` is a [PEP-420 style namespace package](https://www.python.org/dev/peps/pep-0420/). This mechanism is used by Python-based SystemLink services, allowing the service code to live under the `systemlink` namespace, but exist elsewhere on the module search path, sandboxed outside of `site-packages`. After installing `nisystemlink-clients-python`, an `__init__.py` is dropped in the `site-packages` portion of the namespace, causing Python to ignore other packages within the namespace, elsewhere in the search path.

As [documented](https://packaging.python.org/guides/packaging-namespace-packages/):
> It is extremely important that every distribution that uses the namespace package omits the __init__.py or uses a pkgutil-style __init__.py. If any distribution does not, it will cause the namespace logic to fail and the other sub-packages will not be importable.

### Why should this Pull Request be merged?

This PR causes the `__init__.py` in the `systemlink` namespace to be omitted from the produced .whl, restoring the PEP-420 behavior.

There are [numerous](https://github.com/python/mypy/issues/8944) [issues](https://github.com/python/mypy/issues/5759) when using mypy on namespace packages, so the `__init__.py` in the `systemlink` directory is not actually removed as part of this PR. As far as mypy is concerned, this is a regular package. The `setup.py` is updated to treat `systemlink` as a namespace package, and that `__init__.py` is not included in the .whl.

### What testing has been done?

Manually inspected the generated .whl to ensure that the file was not present. Installed the generated package and verified that other `systemlink` modules elsewhere on the search path were importable. Installed the generated package by itself on a fresh system and verified that it is importable.
