### PR TITLE
[setup.py] Prevent tests from being included in .whl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 pypi_name = "nisystemlink-clients"
 
 packages = find_namespace_packages(include=["systemlink.*"]) + find_packages(
-    exclude=["systemlink", "examples", "examples.*", "tests", "tests.*"]
+    exclude=["systemlink", "systemlink.*", "examples", "examples.*", "tests", "tests.*"]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 pypi_name = "nisystemlink-clients"
 
 packages = find_namespace_packages(include=["systemlink.*"]) + find_packages(
-    exclude=["systemlink", "examples", "tests"]
+    exclude=["systemlink", "examples", "examples.*", "tests", "tests.*"]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,7 @@ class PyTest(TestCommand):
 
 pypi_name = "nisystemlink-clients"
 
-packages = find_namespace_packages(include=["systemlink.*"]) + find_packages(
-    exclude=["systemlink", "systemlink.*", "examples", "examples.*", "tests", "tests.*"]
-)
+packages = find_namespace_packages(include=["systemlink.*"])
 
 
 def _get_version(name):

--- a/systemlink/clients/tag/_tag_data.py
+++ b/systemlink/clients/tag/_tag_data.py
@@ -60,9 +60,7 @@ class TagData:
     def from_json_dict(cls, data: Dict[str, Any]) -> "TagData":
         data_type_str = data.get("type") or "UNKNOWN"
         data_type = tbase.DataType.from_api_name(data_type_str)
-        tag = cls(
-            data["path"], data_type, data.get("keywords"), data.get("properties")
-        )
+        tag = cls(data["path"], data_type, data.get("keywords"), data.get("properties"))
         if data.get("collectAggregates"):
             tag.collect_aggregates = True
         return tag

--- a/systemlink/clients/tag/_tag_data.py
+++ b/systemlink/clients/tag/_tag_data.py
@@ -61,7 +61,7 @@ class TagData:
         data_type_str = data.get("type") or "UNKNOWN"
         data_type = tbase.DataType.from_api_name(data_type_str)
         tag = cls(
-            data["path"], data_type, data.get("keywords"), data.get("properties"),
+            data["path"], data_type, data.get("keywords"), data.get("properties")
         )
         if data.get("collectAggregates"):
             tag.collect_aggregates = True

--- a/systemlink/clients/tag/_tag_manager.py
+++ b/systemlink/clients/tag/_tag_manager.py
@@ -752,7 +752,7 @@ class TagManager(tbase.ITagReader):
             response3, http_response = self._api.get(
                 "/tags/{path}/values/current/value", params={"path": path}
             )
-            return self._handle_read(path, response3, http_response,)
+            return self._handle_read(path, response3, http_response)
 
     async def _read_async(
         self, path: str, include_timestamp: bool, include_aggregates: bool
@@ -799,7 +799,7 @@ class TagManager(tbase.ITagReader):
             response3, http_response = await self._api.as_async.get(
                 "/tags/{path}/values/current/value", params={"path": path}
             )
-            return self._handle_read(path, response3, http_response,)
+            return self._handle_read(path, response3, http_response)
 
     def _handle_read(
         self,

--- a/tests/integration/tag/test_tagmanager.py
+++ b/tests/integration/tag/test_tagmanager.py
@@ -203,7 +203,7 @@ class TagManagerTests:
                     ]
                 )
                 self.internal_test_write_and_read_tag(
-                    tag, writer, tbase.TagValueReader(self.tag_manager, tag), 3.0,
+                    tag, writer, tbase.TagValueReader(self.tag_manager, tag), 3.0
                 )
                 self.tag_manager.delete([tag])
 

--- a/tests/tag/http/test_httpbufferedtagwriter.py
+++ b/tests/tag/http/test_httpbufferedtagwriter.py
@@ -27,7 +27,7 @@ class TestHttpBufferedTagWriter(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 1
         call = self._client.all_requests.call_args_list[0]
-        assert ("POST", "/nitag/v2/update-current-values",) == call[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call[0]
         data = call[1].get("data")
         assert isinstance(data, list)
         assert len(data) == 1
@@ -52,7 +52,7 @@ class TestHttpBufferedTagWriter(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 1
         call = self._client.all_requests.call_args_list[0]
-        assert ("POST", "/nitag/v2/update-current-values",) == call[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call[0]
         data = call[1].get("data")
         assert isinstance(data, list)
         assert len(data) == 1
@@ -83,7 +83,7 @@ class TestHttpBufferedTagWriter(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 1
         call = self._client.all_requests.call_args_list[0]
-        assert ("POST", "/nitag/v2/update-current-values",) == call[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call[0]
         data = call[1]["data"]
         assert len(data) == 2
         assert data[0]["path"] == path1
@@ -116,7 +116,7 @@ class TestHttpBufferedTagWriter(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 1
         call = self._client.all_requests.call_args_list[0]
-        assert ("POST", "/nitag/v2/update-current-values",) == call[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call[0]
         data = call[1]["data"]
         assert data[0]["path"] == path
         utctime = datetime.utcfromtimestamp(timestamp.timestamp()).isoformat() + "Z"
@@ -138,8 +138,8 @@ class TestHttpBufferedTagWriter(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 2
         call1, call2 = self._client.all_requests.call_args_list
-        assert ("POST", "/nitag/v2/update-current-values",) == call1[0]
-        assert ("POST", "/nitag/v2/update-current-values",) == call2[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call1[0]
+        assert ("POST", "/nitag/v2/update-current-values") == call2[0]
         data1 = call1[1]["data"]
         data2 = call2[1]["data"]
         assert data1[0]["path"] == path

--- a/tests/tag/http/test_httptagselection.py
+++ b/tests/tag/http/test_httptagselection.py
@@ -19,7 +19,7 @@ class TestHttpTagSelection(HttpClientTestBase):
             if method == "DELETE":
                 ret = None
             elif uri.startswith("/nitag/v2/selections"):
-                if uri in ("/nitag/v2/selections", "/nitag/v2/selections/{id}",):
+                if uri in ("/nitag/v2/selections", "/nitag/v2/selections/{id}"):
                     data = dict(data)
                     data.update({"id": token})
                     ret = data
@@ -317,7 +317,7 @@ class TestHttpTagSelection(HttpClientTestBase):
         ]
 
     @pytest.mark.asyncio
-    async def test__create_subscription_async__subscription_created_with_paths(self,):
+    async def test__create_subscription_async__subscription_created_with_paths(self):
         path1 = "tag1"
         path2 = "tag2"
         token = uuid.uuid4()

--- a/tests/tag/http/test_httptagsubscription.py
+++ b/tests/tag/http/test_httptagsubscription.py
@@ -123,7 +123,7 @@ class TestHttpTagSubscription(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 3
         self._client.all_requests.assert_called_with(
-            "GET", "/nitag/v2/subscriptions/{id}/values/current", params={"id": token},
+            "GET", "/nitag/v2/subscriptions/{id}/values/current", params={"id": token}
         )
         assert timer.start.call_count == 2
         assert len(timer.method_calls) == 2
@@ -244,7 +244,7 @@ class TestHttpTagSubscription(HttpClientTestBase):
 
         assert self._client.all_requests.call_count == 3
         self._client.all_requests.assert_called_with(
-            "GET", "/nitag/v2/subscriptions/{id}/values/current", params={"id": token},
+            "GET", "/nitag/v2/subscriptions/{id}/values/current", params={"id": token}
         )
 
     def test__update_fails__update_timer_elapsed__error_ignored(self):

--- a/tests/tag/test_tagmanager.py
+++ b/tests/tag/test_tagmanager.py
@@ -519,7 +519,7 @@ class TestTagManager(HttpClientTestBase):
         assert dummy_tag.retention_type == tag.retention_type
 
     @pytest.mark.asyncio
-    async def test__tag_not_found__open_async_with_create_False__raises(self,):
+    async def test__tag_not_found__open_async_with_create_False__raises(self):
         err = core.ApiError()
         err.name = "Tag.NoSuchTag"
         ex = core.ApiException("404 tag not found", err)
@@ -534,7 +534,7 @@ class TestTagManager(HttpClientTestBase):
         )
 
     @pytest.mark.asyncio
-    async def test__tag_exists_with_different_datatype__open_async__raises(self,):
+    async def test__tag_exists_with_different_datatype__open_async__raises(self):
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request([{"type": "BOOLEAN", "path": "tag"}] * 3)
         )


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Manually open all prior versions of the .whl and notice that it contains a `tests` module. These files are also installed when `pip install`ing this package. We don't need to distribute tests, and they bloat the package unnecessarily.

### Why should this Pull Request be merged?

This change updates the package exclusion rules to properly leave out everything under the `tests` directory.

In previous versions, there was an exclusion rule for `tests`, but this only instructs setup.py to exclude everything directly in the `tests` module, but does not exclude submodules. To exclude a module and its submodules, both `mymodule` and `mymodule.*` should be excluded - see [these docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages).

Examples were already not included because they do not contain an `__init__.py`. However for future-proofing, I explicitly added examples to the exclusion rules as well, in case an init is ever added.

### What testing has been done?

Built the .whl. Verified that `tests` was no longer present.
