### PR TITLE
send tag writes on buffered tag exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /*.egg-info/
 /.tox
 /.venv
+/.vscode
 __pycache__/
 .mypy_cache/
 build/

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=packages,
     install_requires=[
         'aenum;python_version<"3.6"',
-        "events==0.3",
+        "events",
         'httpx;python_version>="3.6"',
         'requests;python_version<"3.6"',
         "typing-extensions",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=packages,
     install_requires=[
         'aenum;python_version<"3.6"',
-        "events",
+        "events==0.3",
         'httpx;python_version>="3.6"',
         'requests;python_version<"3.6"',
         "typing-extensions",

--- a/systemlink/clients/tag/_buffered_tag_writer.py
+++ b/systemlink/clients/tag/_buffered_tag_writer.py
@@ -198,7 +198,6 @@ class BufferedTagWriter(tbase.ITagWriter):
             return False
 
         self.send_buffered_writes()
-        self._timer_generation += 1
         self._closed = True
 
         suppress = self._flush_timer.__exit__(exc_type, exc_val, exc_tb)
@@ -214,7 +213,6 @@ class BufferedTagWriter(tbase.ITagWriter):
             return False
 
         await self.send_buffered_writes_async()
-        self._timer_generation += 1
         self._closed = True
 
         suppress = await self._flush_timer.__aexit__(exc_type, exc_val, exc_tb)

--- a/systemlink/clients/tag/_buffered_tag_writer.py
+++ b/systemlink/clients/tag/_buffered_tag_writer.py
@@ -197,6 +197,7 @@ class BufferedTagWriter(tbase.ITagWriter):
         if self._closed:
             return False
 
+        self.send_buffered_writes()
         self._timer_generation += 1
         self._closed = True
 
@@ -212,6 +213,7 @@ class BufferedTagWriter(tbase.ITagWriter):
         if self._closed:
             return False
 
+        await self.send_buffered_writes_async()
         self._timer_generation += 1
         self._closed = True
 

--- a/tests/tag/http/test_httptagsubscription.py
+++ b/tests/tag/http/test_httptagsubscription.py
@@ -103,7 +103,7 @@ class TestHttpTagSubscription(HttpClientTestBase):
             self._client, paths, timer, ManualResetTimer.null_timer
         )
 
-        assert uut
+        assert uut is not None
         assert self._client.all_requests.call_args_list == [
             mock.call(
                 "POST",
@@ -580,7 +580,7 @@ class TestHttpTagSubscription(HttpClientTestBase):
         uut = HttpTagSubscription.create(
             self._client, [], ManualResetTimer.null_timer, timer
         )
-        assert uut
+        assert uut is not None
         assert timer.start.call_count == 1
 
         timer.elapsed()
@@ -606,7 +606,7 @@ class TestHttpTagSubscription(HttpClientTestBase):
             self._client, paths, ManualResetTimer.null_timer, timer
         )
 
-        assert uut
+        assert uut is not None
         assert timer.start.call_count == 1
         assert self._client.all_requests.call_count == 2
         assert self._client.all_requests.call_args_list == [

--- a/tests/tag/test_bufferedtagwriter.py
+++ b/tests/tag/test_bufferedtagwriter.py
@@ -601,7 +601,7 @@ class TestBufferedTagWriter:
 
         with writer:
             writer.write("tag", tbase.DataType.DOUBLE, 1.1, timestamp=self.timestamp)
-        
+
         writer.mock_send_writes.assert_called_once_with(buffer)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This makes the buffered tag writer send any buffered writes on exit.

### Why should this Pull Request be merged?

Resolves #14 

### What testing has been done?

Ran all the tests that didn't need a local instance of SystemLink Server or the SystemLink Cloud setup.
