### PR TITLE
Add JupyterHttpConfiguration class

### DIFF
--- a/systemlink/clients/core/__init__.py
+++ b/systemlink/clients/core/__init__.py
@@ -4,6 +4,7 @@ from ._api_error import ApiError
 from ._api_exception import ApiException
 from ._http_configuration import HttpConfiguration
 from ._cloud_http_configuration import CloudHttpConfiguration
+from ._jupyter_http_configuration import JupyterHttpConfiguration
 from ._http_configuration_manager import HttpConfigurationManager
 
 # flake8: noqa

--- a/systemlink/clients/core/_jupyter_http_configuration.py
+++ b/systemlink/clients/core/_jupyter_http_configuration.py
@@ -8,7 +8,7 @@ from systemlink.clients import core
 
 
 class JupyterHttpConfiguration(core.HttpConfiguration):
-    """An :class:`HttpConfiguration` specifically for use in Jupyter notebooks."""
+    """An :class:`HttpConfiguration` for Jupyter notebooks running in a SystemLink environment."""
 
     _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
     _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"

--- a/systemlink/clients/core/_jupyter_http_configuration.py
+++ b/systemlink/clients/core/_jupyter_http_configuration.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+"""Implementation of JupyterHttpConfiguration."""
+
+import os
+
+from systemlink.clients import core
+
+
+class JupyterHttpConfiguration(core.HttpConfiguration):
+    """An :class:`HttpConfiguration` specifically for use in Jupyter notebooks."""
+
+    _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
+    _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
+
+    def __init__(self) -> None:
+        """Initialize a configuration for SystemLink using API key-based
+        authentication provided through environment variables.
+
+        Raises:
+            KeyError: if the expected environment variables are not set.
+        """
+        super().__init__(
+            os.environ[self._HTTP_URI_ENV_VAR], os.environ[self._HTTP_API_KEY_ENV_VAR]
+        )


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `JupyterHttpConfiguration` class for use in Jupyter notebook environments.

### Why should this Pull Request be merged?

This env variable based configuration is necessary for clients to work in notebooks.

### What testing has been done?

We don't seem to have any unit tests around the config classes. There's really no functionality here other than reading env variables, so I didn't bother trying to create tests. We may be able to use this in integration tests for the DFS client later on.
