### PR TITLE
Disallow extra Pydantic fields in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,5 +87,5 @@ def enterprise_config(pytestconfig):
 
 @pytest.fixture(scope="session", autouse=True)
 def pydantic_forbid_extra_fields():
-    """Fixture to disable allowing extra fields in Pydantic models."""
+    """Fixture to disable allowing extra fields in our Pydantic models."""
     JsonModel.Config.extra = Extra.forbid

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest  # type: ignore
 from nisystemlink.clients import core
+from nisystemlink.clients.core._uplink._json_model import JsonModel
+from pydantic import Extra
 
 
 def pytest_addoption(parser):
@@ -68,6 +70,7 @@ def server_config(pytestconfig):
     except core.ApiException:
         pytest.skip("--web-server-* settings not found, nor localhost config file")
 
+
 @pytest.fixture(scope="class")
 def enterprise_config(pytestconfig):
     """Fixture to get a HttpConfiguration for testing Enterprise integration.
@@ -80,3 +83,9 @@ def enterprise_config(pytestconfig):
         return core.HttpConfiguration(uri, api_key)
     else:
         pytest.skip("--enterprise-uri or --enterprise-api-key setting not found")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def pydantic_forbid_extra_fields():
+    """Fixture to disable allowing extra fields in Pydantic models."""
+    JsonModel.Config.extra = Extra.forbid


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a session-level pytest fixture that sets the ["extra" config in Pydantic](https://pydantic-docs.helpmanual.io/usage/model_config/#options) models to "forbid".

### Why should this Pull Request be merged?

Using this fixture will cause our tests to fail when new fields are added to DFS resources. This will force us to keep the client in sync with the service.

### What testing has been done?

Ran tests locally and verified that it causes failures as expected.
