### PR TITLE
chore: Split semantic-release out to a separate job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -43,7 +44,6 @@ jobs:
           cache: "poetry"
       - run: poetry install
       - name: Semantic release
-        # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         run: |
           pip install python-semantic-release
           semantic-release publish --verbosity=DEBUG

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,8 +14,6 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Install poetry
         run: pipx install poetry
       - uses: actions/setup-python@v4
@@ -30,8 +28,22 @@ jobs:
       - run: poetry run poe check
       - run: poetry run poe lint
       - run: poetry run poe types
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: "poetry"
+      - run: poetry install
       - name: Semantic release
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         run: |
           pip install python-semantic-release
           semantic-release publish --verbosity=DEBUG


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Splits the semantic-release step out to a separate job. The "build" step currently runs against a matrix of Python versions and we don't want to run the semantic-release tool multiple times.

### Why should this Pull Request be merged?

Avoids an issue where we would attempt to build 4 releases per submission.

### What testing has been done?

Commented out the conditional on the new job and verified it attempts to build a release (once):
https://github.com/ni/nisystemlink-clients-python/actions/runs/3482629028/jobs/5825222594

Current PR build shows that the job is skipped with the conditional uncommented.