### PR TITLE
feat: Method to update table metadata

### DIFF
--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -109,7 +109,7 @@ class DataFrameClient(BaseClient):
 
     @json
     @patch(_BASE_PATH + "/tables/{id}", args=(Path, Body))
-    def update_table_metadata(self, id: str, update: models.ModifyTableRequest) -> None:
+    def modify_table(self, id: str, update: models.ModifyTableRequest) -> None:
         """Modify properties of a table or its columns.
 
         Args:

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
-from uplink import Body, delete, get, json, post, Query, returns
+from uplink import Body, Path, delete, get, json, patch, post, Query, returns
 
 from . import models
 
@@ -104,6 +104,17 @@ class DataFrameClient(BaseClient):
 
         Returns:
             models.TableMetadata: The metadata for the table.
+        """
+        ...
+
+    @json
+    @patch(_BASE_PATH + "/tables/{id}", args=(Path, Body))
+    def update_table_metadata(self, id: str, update: models.ModifyTableRequest) -> None:
+        """Modify properties of a table or its columns.
+
+        Args:
+            id: Unique ID of a DataFrame table.
+            update: The metadata to update.
         """
         ...
 

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
-from uplink import Body, Path, delete, get, json, patch, post, Query, returns
+from uplink import Body, delete, get, json, patch, Path, post, Query, returns
 
 from . import models
 

--- a/nisystemlink/clients/dataframe/models/__init__.py
+++ b/nisystemlink/clients/dataframe/models/__init__.py
@@ -3,6 +3,7 @@ from ._create_table_request import CreateTableRequest
 from ._column import Column
 from ._column_type import ColumnType
 from ._data_type import DataType
+from ._modify_table_request import ColumnMetadataPatch, ModifyTableRequest
 from ._order_by import OrderBy
 from ._paged_tables import PagedTables
 from ._query_tables_request import QueryTablesRequest

--- a/nisystemlink/clients/dataframe/models/_modify_table_request.py
+++ b/nisystemlink/clients/dataframe/models/_modify_table_request.py
@@ -1,0 +1,44 @@
+from typing import Dict, List, Optional
+
+from nisystemlink.clients.core._uplink._json_model import JsonModel
+
+
+class ColumnMetadataPatch(JsonModel):
+    """Specifies column properties to add, modify, or delete when editing table metadata."""
+
+    name: str
+    """The name of the column to modify."""
+
+    properties: Dict[str, Optional[str]]
+    """The properties to modify. A map of key value properties containing the metadata
+    to be added or modified. Setting a property value to ``None`` will delete the
+    property."""
+
+
+class ModifyTableRequest(JsonModel):
+    """Contains the metadata properties to modify. Values not included will remain unchanged."""
+
+    metadata_revision: Optional[int] = None
+    """When specified, this is an integer that must match the last known
+    revision number of the table, incremented by one. If it doesn't match the
+    current ``metadataRevision`` incremented by one at the time of execution, the
+    modify request will be rejected with a 409 Conflict. This is used to ensure
+    that changes to this table's metadata are based on a known, previous
+    state."""
+
+    name: Optional[str] = None
+    """The new name of the table. Setting to ``None`` will reset the name to the table's ID."""
+
+    workspace: Optional[str] = None
+    """The new workspace for the table. Setting to ``None`` will reset to the
+    default workspace. Changing the workspace requires permission to delete the
+    table in its current workspace and permission to create the table in its new
+    workspace."""
+
+    properties: Optional[Dict[str, Optional[str]]] = None
+    """The properties to modify. A map of key value properties containing the
+    metadata to be added or modified. Setting a property value to ``None`` will
+    delete the property."""
+
+    columns: Optional[List[ColumnMetadataPatch]] = None
+    """Updates to the column properties. Cannot add or remove columns, or change the name of a column."""

--- a/tests/integration/dataframe/test_dataframe.py
+++ b/tests/integration/dataframe/test_dataframe.py
@@ -170,7 +170,7 @@ class TestDataFrame:
             )
         )
 
-        client.update_table_metadata(
+        client.modify_table(
             id,
             models.ModifyTableRequest(
                 metadata_revision=2,
@@ -190,7 +190,7 @@ class TestDataFrame:
         assert table.properties == {"cow": "moo"}
         assert table.columns[0].properties == {"sheep": "baa"}
 
-        client.update_table_metadata(
+        client.modify_table(
             id, models.ModifyTableRequest(properties={"bee": "buzz"})
         )
         table = client.get_table_metadata(id)
@@ -198,7 +198,7 @@ class TestDataFrame:
         assert table.properties == {"cow": "moo", "bee": "buzz"}
         assert table.name == "Modified table"
 
-        client.update_table_metadata(
+        client.modify_table(
             id,
             models.ModifyTableRequest(
                 metadata_revision=4,

--- a/tests/integration/dataframe/test_dataframe.py
+++ b/tests/integration/dataframe/test_dataframe.py
@@ -190,9 +190,7 @@ class TestDataFrame:
         assert table.properties == {"cow": "moo"}
         assert table.columns[0].properties == {"sheep": "baa"}
 
-        client.modify_table(
-            id, models.ModifyTableRequest(properties={"bee": "buzz"})
-        )
+        client.modify_table(id, models.ModifyTableRequest(properties={"bee": "buzz"}))
         table = client.get_table_metadata(id)
 
         assert table.properties == {"cow": "moo", "bee": "buzz"}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds `update_table_metdata`method to patch table metdata.
The behavior of setting `null` to remove properties/fields relies on Pydantic's `exclude_unset` config: https://pydantic-docs.helpmanual.io/usage/exporting_models/

### What testing has been done?

- Added automated test

### Open Issues

Does anyone have input on the naming for the patch methods? I wasn't sure what to go with.
- `modify_table_metadata`
- `modify_table(s)`
- `patch_table(s)`

Keep in mind that we will need a name for the multi-patch method as well.