### PR TITLE
feat: Table multi-delete + refactoring core libs

### DIFF
--- a/nisystemlink/clients/core/_api_error.py
+++ b/nisystemlink/clients/core/_api_error.py
@@ -2,181 +2,31 @@
 
 """Implementation of ApiError."""
 
-import typing
-from typing import Any, Dict, Iterable, List, Optional
+from typing import List, Optional
 
-from typing_extensions import final
+from ._uplink._json_model import JsonModel
 
 
-@final
-class ApiError:
+class ApiError(JsonModel):
     """Represents the standard error structure for SystemLink API responses."""
 
-    def __init_subclass__(cls) -> None:
-        raise TypeError("type 'ApiError' is not an acceptable base type")
+    name: Optional[str] = None
+    """String error code."""
 
-    def __init__(self) -> None:
-        self._name = None  # type: Optional[str]
-        self._code = None  # type: Optional[int]
-        self._message = None  # type: Optional[str]
-        self._args = []  # type: List[str]
-        self._resource_type = None  # type: Optional[str]
-        self._resource_id = None  # type: Optional[str]
-        self._inner_errors = []  # type: List[ApiError]
+    code: Optional[str] = None
+    """Numeric error code."""
 
-    @property
-    def name(self) -> Optional[str]:  # noqa: D401
-        """The name of the error."""
-        return self._name
+    message: Optional[str] = None
+    """Complete error message."""
 
-    @name.setter
-    def name(self, value: Optional[str]) -> None:
-        self._name = value
+    args: List[str] = []
+    """Positional arguments for the error code."""
 
-    @property
-    def code(self) -> Optional[int]:  # noqa: D401
-        """The numeric code associated with the error."""
-        return self._code
+    resource_type: Optional[str] = None
+    """Type of resource associated with the error."""
 
-    @code.setter
-    def code(self, value: Optional[int]) -> None:
-        self._code = value
+    resource_id: Optional[str] = None
+    """Identifier of the resource associated with the error."""
 
-    @property
-    def message(self) -> Optional[str]:  # noqa: D401
-        """The error message."""
-        return self._message
-
-    @message.setter
-    def message(self, value: Optional[str]) -> None:
-        self._message = value
-
-    @property
-    def args(self) -> List[str]:  # noqa: D401
-        """The list of positional arguments formatted into the error."""
-        return self._args
-
-    @args.setter
-    def args(self, value: Iterable[str]) -> None:
-        self._args = list(value)
-
-    @property
-    def resource_type(self) -> Optional[str]:  # noqa: D401
-        """The type of resource associated with the error, if any.
-
-        Set this when setting :attr:`resource_id`.
-        """
-        return self._resource_type
-
-    @resource_type.setter
-    def resource_type(self, value: Optional[str]) -> None:
-        self._resource_type = value
-
-    @property
-    def resource_id(self) -> Optional[str]:  # noqa: D401
-        """The ID of the resource associated with the error, if any.
-
-        Set :attr:`resource_type` when setting this property.
-        """
-        return self._resource_id
-
-    @resource_id.setter
-    def resource_id(self, value: Optional[str]) -> None:
-        self._resource_id = value
-
-    @property
-    def inner_errors(self) -> List["ApiError"]:  # noqa: D401
-        """The list of inner errors."""
-        return self._inner_errors
-
-    @inner_errors.setter
-    def inner_errors(self, value: Iterable["ApiError"]) -> None:
-        self._inner_errors = list(value)
-
-    def copy(self) -> "ApiError":
-        """Get a copy of this object."""
-        new = ApiError()
-        new.name = self.name
-        new.code = self.code
-        new.message = self.message
-        new.args = self.args
-        new.resource_type = self.resource_type
-        new.resource_id = self.resource_id
-        new.inner_errors = self.inner_errors
-        return new
-
-    def __str__(self) -> str:
-        txt = ""
-        if self._name:
-            txt += "Name: {}\n".format(self._name)
-        if self._code:
-            txt += "Code: {}\n".format(self._code)
-        if self._message:
-            txt += "Message: {}\n".format(self._message)
-        if self._args:
-            args = "\n  ".join(self._args)
-            txt += "Args:\n  {}\n".format(args)
-        if self._resource_type:
-            txt += "Resource Type: {}\n".format(self._resource_type)
-        if self._resource_id:
-            txt += "Resource Id: {}\n".format(self._resource_id)
-        if self._inner_errors:
-            inner_errors = "\n  ".join(str(e) for e in self._inner_errors)
-            txt += "Inner Errors:\n  {}\n".format(
-                str(inner_errors).replace("\n", "\n  ")
-            )
-        return txt[:-1]
-
-    def __repr__(self) -> str:
-        return (
-            "ApiError(name={!r}, code={!r}, message={!r}, args={!r}, "
-            "resource_type={!r}, resource_id={!r}, inner_errors={!r})".format(
-                self.name,
-                self.code,
-                self.message,
-                self.args,
-                self.resource_type,
-                self.resource_id,
-                self.inner_errors,
-            )
-        )
-
-    def __eq__(self, other: object) -> bool:
-        other_ = typing.cast(ApiError, other)
-        return all(
-            (
-                isinstance(other, ApiError),
-                self.name == other_.name,
-                self.code == other_.code,
-                self.message == other_.message,
-                self.args == other_.args,
-                self.resource_type == other_.resource_type,
-                self.resource_id == other_.resource_id,
-                self.inner_errors == other_.inner_errors,
-            )
-        )
-
-    def __hash__(self) -> int:
-        return hash(
-            (
-                self.name,
-                self.code,
-                self.message,
-                tuple(self.args),
-                self.resource_type,
-                self.resource_id,
-                tuple(self.inner_errors),
-            )
-        )
-
-    @classmethod
-    def from_json_dict(cls, data: Dict[str, Any]) -> "ApiError":
-        err = cls()
-        err.name = data.get("name")
-        err.code = data.get("code")
-        err.message = data.get("message")
-        err.args = data.get("args", [])
-        err.resource_type = data.get("resourceType")
-        err.resource_id = data.get("resourceId")
-        err.inner_errors = [cls.from_json_dict(e) for e in data.get("innerErrors", [])]
-        return err
+    inner_errors: List["ApiError"] = []
+    """Inner errors when the top-level error represents more than one error."""

--- a/nisystemlink/clients/core/_api_error.py
+++ b/nisystemlink/clients/core/_api_error.py
@@ -13,7 +13,7 @@ class ApiError(JsonModel):
     name: Optional[str] = None
     """String error code."""
 
-    code: Optional[str] = None
+    code: Optional[int] = None
     """Numeric error code."""
 
     message: Optional[str] = None

--- a/nisystemlink/clients/core/_internal/_http_client.py
+++ b/nisystemlink/clients/core/_internal/_http_client.py
@@ -286,7 +286,7 @@ def _handle_response(response: HttpResponse, method: str, uri: str) -> Any:
 
         if data:
             err_dict = typing.cast(Dict[str, Any], data).get("error", {})
-            err_obj = core.ApiError.from_json_dict(err_dict) if err_dict else None
+            err_obj = core.ApiError.parse_obj(err_dict) if err_dict else None
         else:
             err_obj = None
 

--- a/nisystemlink/clients/core/_uplink/_base_client.py
+++ b/nisystemlink/clients/core/_uplink/_base_client.py
@@ -85,12 +85,3 @@ class BaseClient(Consumer):
         )
         if configuration.api_keys:
             self.session.headers.update(configuration.api_keys)
-
-
-# def get(uri: str, args: Optional[Sequence[Any]] = None) -> Callable[[F], F]:
-#     def decorator(func: F) -> F:
-#         if not args:
-#             spec = utils.get_arg_spec(func)
-#             default_args = [Query(_camelcase(arg)) for arg in spec.args[1:]]
-#         return commands.get(uri, args=args or default_args)(func)  # type: ignore
-#     return decorator

--- a/nisystemlink/clients/core/_uplink/_methods.py
+++ b/nisystemlink/clients/core/_uplink/_methods.py
@@ -1,0 +1,53 @@
+"""Wrappers around uplink HTTP decorators with proper type annotations."""
+
+from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union
+
+from uplink import Body, commands, json, returns
+
+F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T", bound=Type)
+
+
+def get(path: str, args: Optional[Sequence[Any]] = None) -> Callable[[F], F]:
+    """Annotation for a GET request."""
+
+    def decorator(func: F) -> F:
+        return commands.get(path, args=args)(func)  # type: ignore
+
+    return decorator
+
+
+def post(
+    path: str,
+    args: Optional[Sequence[Any]] = None,
+    return_key: Optional[Union[str, Tuple[str, ...]]] = None,
+) -> Callable[[F], F]:
+    """Annotation for a POST request with a JSON request body. If args is not
+    specified, defaults to a single argument that represents the request body.
+    """
+
+    def decorator(func: F) -> F:
+        result = json(commands.post(path, args=args or (Body,))(func))
+        if return_key:
+            result = returns.json(key=return_key)(result)
+        return result  # type: ignore
+
+    return decorator
+
+
+def patch(path: str, args: Optional[Sequence[Any]] = None) -> Callable[[F], F]:
+    """Annotation for a PATCH request with a JSON request body."""
+
+    def decorator(func: F) -> F:
+        return json(commands.patch(path, args=args)(func))  # type: ignore
+
+    return decorator
+
+
+def delete(path: str, args: Optional[Sequence[Any]] = None) -> Callable[[F], F]:
+    """Annotation for a DELETE request."""
+
+    def decorator(func: F) -> F:
+        return commands.delete(path, args=args)(func)  # type: ignore
+
+    return decorator

--- a/nisystemlink/clients/core/_uplink/_methods.py
+++ b/nisystemlink/clients/core/_uplink/_methods.py
@@ -1,11 +1,10 @@
 """Wrappers around uplink HTTP decorators with proper type annotations."""
 
-from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Sequence, Tuple, TypeVar, Union
 
 from uplink import Body, commands, json, returns
 
 F = TypeVar("F", bound=Callable[..., Any])
-T = TypeVar("T", bound=Type)
 
 
 def get(path: str, args: Optional[Sequence[Any]] = None) -> Callable[[F], F]:

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -1,13 +1,11 @@
-# TODO: Wrap Uplink decorators to add typing information
-# mypy: disable-error-code = misc
-
 """Implementation of DataFrameClient."""
 
 from typing import List, Optional
 
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
-from uplink import Body, delete, get, json, patch, Path, post, Query, returns
+from nisystemlink.clients.core._uplink._methods import delete, get, patch, post
+from uplink import Body, Field, Path, Query
 
 from . import models
 
@@ -68,9 +66,7 @@ class DataFrameClient(BaseClient):
         """
         ...
 
-    @json
-    @returns.json(key="id")
-    @post(_BASE_PATH + "/tables", args=(Body,))
+    @post(_BASE_PATH + "/tables", return_key="id")
     def create_table(self, table: models.CreateTableRequest) -> str:
         """Create a new table with the provided metadata and column definitions.
 
@@ -82,8 +78,7 @@ class DataFrameClient(BaseClient):
         """
         ...
 
-    @json
-    @post(_BASE_PATH + "/query-tables", args=(Body,))
+    @post(_BASE_PATH + "/query-tables")
     def query_tables(self, query: models.QueryTablesRequest) -> models.PagedTables:
         """Queries available tables on the SystemLink DataFrame service and returns their metadata.
 
@@ -107,8 +102,7 @@ class DataFrameClient(BaseClient):
         """
         ...
 
-    @json
-    @patch(_BASE_PATH + "/tables/{id}", args=(Path, Body))
+    @patch(_BASE_PATH + "/tables/{id}", args=[Path, Body])
     def modify_table(self, id: str, update: models.ModifyTableRequest) -> None:
         """Modify properties of a table or its columns.
 
@@ -124,5 +118,16 @@ class DataFrameClient(BaseClient):
 
         Args:
             id (str): Unique ID of a DataFrame table.
+        """
+        ...
+
+    @post(_BASE_PATH + "/delete-tables", args=[Field("ids")])
+    def delete_tables(
+        self, ids: List[str]
+    ) -> Optional[models.DeleteTablesPartialSuccess]:
+        """Deletes multiple tables.
+
+        Args:
+            ids (List[str]): List of unique IDs of DataFrame tables.
         """
         ...

--- a/nisystemlink/clients/dataframe/models/__init__.py
+++ b/nisystemlink/clients/dataframe/models/__init__.py
@@ -3,6 +3,7 @@ from ._create_table_request import CreateTableRequest
 from ._column import Column
 from ._column_type import ColumnType
 from ._data_type import DataType
+from ._delete_tables_partial_success import DeleteTablesPartialSuccess
 from ._modify_table_request import ColumnMetadataPatch, ModifyTableRequest
 from ._order_by import OrderBy
 from ._paged_tables import PagedTables

--- a/nisystemlink/clients/dataframe/models/_delete_tables_partial_success.py
+++ b/nisystemlink/clients/dataframe/models/_delete_tables_partial_success.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from nisystemlink.clients.core import ApiError
+from nisystemlink.clients.core._uplink._json_model import JsonModel
+
+
+class DeleteTablesPartialSuccess(JsonModel):
+    """The result of deleting multiple tables when one or more tables could not be deleted."""
+
+    deleted_table_ids: List[str]
+    """The IDs of the tables that were successfully deleted."""
+
+    failed_table_ids: List[str]
+    """The IDs of the tables that could not be deleted."""
+
+    error: ApiError
+    """The error that occurred when deleting the tables."""

--- a/nisystemlink/clients/tag/_tag_manager.py
+++ b/nisystemlink/clients/tag/_tag_manager.py
@@ -505,7 +505,7 @@ class TagManager(tbase.ITagReader):
                 # SystemLink Cloud has a bug in which it returns the error directly
                 # instead of under the "error" key
                 err_dict = partial_success
-            err_obj = core.ApiError.from_json_dict(err_dict) if err_dict else None
+            err_obj = core.ApiError.parse_obj(err_dict) if err_dict else None
             if err_dict is None:
                 assert False, partial_success
             raise core.ApiException(error=err_obj)
@@ -546,7 +546,7 @@ class TagManager(tbase.ITagReader):
                 # SystemLink Cloud has a bug in which it returns the error directly
                 # instead of under the "error" key
                 err_dict = partial_success
-            err_obj = core.ApiError.from_json_dict(err_dict) if err_dict else None
+            err_obj = core.ApiError.parse_obj(err_dict) if err_dict else None
             if err_dict is None:
                 assert False, partial_success
             raise core.ApiException(error=err_obj)

--- a/poetry.lock
+++ b/poetry.lock
@@ -107,7 +107,7 @@ python-versions = "*"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -143,7 +143,7 @@ pydocstyle = ">=2.1"
 
 [[package]]
 name = "flake8-import-order"
-version = "0.18.1"
+version = "0.18.2"
 description = "Flake8 and pylama plugin that checks the ordering of import statements."
 category = "dev"
 optional = false
@@ -155,24 +155,24 @@ setuptools = "*"
 
 [[package]]
 name = "h11"
-version = "0.12.0"
+version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "httpcore"
-version = "0.15.0"
+version = "0.16.2"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-anyio = ">=3.0.0,<4.0.0"
+anyio = ">=3.0,<5.0"
 certifi = "*"
-h11 = ">=0.11,<0.13"
+h11 = ">=0.13,<0.15"
 sniffio = ">=1.0.0,<2.0.0"
 
 [package.extras]
@@ -181,7 +181,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.23.0"
+version = "0.23.1"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
@@ -189,7 +189,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.15.0,<0.16.0"
+httpcore = ">=0.15.0,<0.17.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
@@ -270,7 +270,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pathspec"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
@@ -278,15 +278,15 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "2.5.4"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -302,7 +302,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poethepoet"
-version = "0.16.4"
+version = "0.16.5"
 description = "A task runner that works well with poetry."
 category = "dev"
 optional = false
@@ -393,7 +393,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.20.1"
+version = "0.20.2"
 description = "Pytest support for asyncio"
 category = "dev"
 optional = false
@@ -439,7 +439,7 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "setuptools"
-version = "65.5.0"
+version = "65.6.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -447,7 +447,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -484,7 +484,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.4"
+version = "2.28.11.5"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -495,7 +495,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25.3"
+version = "1.26.25.4"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -540,11 +540,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
@@ -608,8 +608,8 @@ events = [
     {file = "Events-0.4.tar.gz", hash = "sha256:01d9dd2a061f908d74a89fa5c8f07baa694f02a2a5974983663faaf7a97180f5"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
-    {file = "exceptiongroup-1.0.0.tar.gz", hash = "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
@@ -620,20 +620,20 @@ flake8-docstrings = [
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
 ]
 flake8-import-order = [
-    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
-    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
+    {file = "flake8-import-order-0.18.2.tar.gz", hash = "sha256:e23941f892da3e0c09d711babbb0c73bc735242e9b216b726616758a920d900e"},
+    {file = "flake8_import_order-0.18.2-py2.py3-none-any.whl", hash = "sha256:82ed59f1083b629b030ee9d3928d9e06b6213eb196fe745b3a7d4af2168130df"},
 ]
 h11 = [
-    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
-    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
 httpcore = [
-    {file = "httpcore-0.15.0-py3-none-any.whl", hash = "sha256:1105b8b73c025f23ff7c36468e4432226cbb959176eab66864b8e31c4ee27fa6"},
-    {file = "httpcore-0.15.0.tar.gz", hash = "sha256:18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b"},
+    {file = "httpcore-0.16.2-py3-none-any.whl", hash = "sha256:52c79095197178856724541e845f2db86d5f1527640d9254b5b8f6f6cebfdee6"},
+    {file = "httpcore-0.16.2.tar.gz", hash = "sha256:c35c5176dc82db732acfd90b581a3062c999a72305df30c0fc8fafd8e4aca068"},
 ]
 httpx = [
-    {file = "httpx-0.23.0-py3-none-any.whl", hash = "sha256:42974f577483e1e932c3cdc3cd2303e883cbfba17fe228b0f63589764d7b9c4b"},
-    {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
+    {file = "httpx-0.23.1-py3-none-any.whl", hash = "sha256:0b9b1f0ee18b9978d637b0776bfd7f54e2ca278e063e3586d8f01cda89e042a8"},
+    {file = "httpx-0.23.1.tar.gz", hash = "sha256:202ae15319be24efe9a8bd4ed4360e68fde7b38bcc2ce87088d416f026667d19"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -686,20 +686,20 @@ pastel = [
     {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
 ]
 pathspec = [
-    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
-    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+    {file = "pathspec-0.10.2-py3-none-any.whl", hash = "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5"},
+    {file = "pathspec-0.10.2.tar.gz", hash = "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+    {file = "platformdirs-2.5.4-py3-none-any.whl", hash = "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"},
+    {file = "platformdirs-2.5.4.tar.gz", hash = "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 poethepoet = [
-    {file = "poethepoet-0.16.4-py3-none-any.whl", hash = "sha256:1f05dce92ca6457d018696b614ba2149261380f30ceb21c196daf19c0c2e1fcd"},
-    {file = "poethepoet-0.16.4.tar.gz", hash = "sha256:a80f6bba64812515c406ffc218aff833951b17854eb111f724b48c44f9759af5"},
+    {file = "poethepoet-0.16.5-py3-none-any.whl", hash = "sha256:493d5d47b4cb0894dde6a69d14129ba39ef3f124fabda1f83ebb39bbf737a40e"},
+    {file = "poethepoet-0.16.5.tar.gz", hash = "sha256:3c958792ce488661ba09df67ba832a1b3141aa640236505ee60c23f4b1db4dbc"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
@@ -760,8 +760,8 @@ pytest = [
     {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
 ]
 pytest-asyncio = [
-    {file = "pytest-asyncio-0.20.1.tar.gz", hash = "sha256:626699de2a747611f3eeb64168b3575f70439b06c3d0206e6ceaeeb956e65519"},
-    {file = "pytest_asyncio-0.20.1-py3-none-any.whl", hash = "sha256:2c85a835df33fda40fe3973b451e0c194ca11bc2c007eabff90bb3d156fc172b"},
+    {file = "pytest-asyncio-0.20.2.tar.gz", hash = "sha256:32a87a9836298a881c0ec637ebcc952cfe23a56436bdc0d09d1511941dd8a812"},
+    {file = "pytest_asyncio-0.20.2-py3-none-any.whl", hash = "sha256:07e0abf9e6e6b95894a39f688a4a875d63c2128f76c02d03d16ccbc35bcc0f8a"},
 ]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
@@ -772,8 +772,8 @@ rfc3986 = [
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 setuptools = [
-    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
-    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
+    {file = "setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
+    {file = "setuptools-65.6.3.tar.gz", hash = "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -792,12 +792,12 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 types-requests = [
-    {file = "types-requests-2.28.11.4.tar.gz", hash = "sha256:d4f342b0df432262e9e326d17638eeae96a5881e78e7a6aae46d33870d73952e"},
-    {file = "types_requests-2.28.11.4-py3-none-any.whl", hash = "sha256:bdb1f9811e53d0642c8347b09137363eb25e1a516819e190da187c29595a1df3"},
+    {file = "types-requests-2.28.11.5.tar.gz", hash = "sha256:a7df37cc6fb6187a84097da951f8e21d335448aa2501a6b0a39cbd1d7ca9ee2a"},
+    {file = "types_requests-2.28.11.5-py3-none-any.whl", hash = "sha256:091d4a5a33c1b4f20d8b1b952aa8fa27a6e767c44c3cf65e56580df0b05fd8a9"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.25.3.tar.gz", hash = "sha256:1807b87b8ee1ae0226813ba2c52330eff20fb2bf6359b1de24df08eb3090e442"},
-    {file = "types_urllib3-1.26.25.3-py3-none-any.whl", hash = "sha256:a188c24fc61a99658c8c324c8dd7419f5b91a0d89df004e5f576869122c1db55"},
+    {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
+    {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
@@ -812,6 +812,6 @@ uritemplate = [
     {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+    {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
+    {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ markers = [
     "enterprise: mark a test as an enterprise integration test",
     "webserver: mark a test as a webserver integration test",
     "slow: mark a test as a slow test",
+    "focus: focus a specific test during development",
 ]
 
 [tool.black]

--- a/tests/integration/dataframe/test_dataframe.py
+++ b/tests/integration/dataframe/test_dataframe.py
@@ -268,4 +268,4 @@ class TestDataFrame:
         assert response is not None
         assert response.deleted_table_ids == [id]
         assert response.failed_table_ids == ["invalid_id"]
-        assert response.error is not None
+        assert len(response.error.inner_errors) == 1

--- a/tests/tag/test_tagmanager.py
+++ b/tests/tag/test_tagmanager.py
@@ -190,8 +190,7 @@ class TestTagManager(HttpClientTestBase):
         assert dummy_tag.retention_type == tag.retention_type
 
     def test___tag_not_found__open_without_datatype__raises(self):
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         ex = core.ApiException("404 tag not found", err)
         self._client.all_requests.configure_mock(side_effect=ex)
 
@@ -205,8 +204,7 @@ class TestTagManager(HttpClientTestBase):
 
     def test___tag_not_found__open_with_datatype__creates_tag(self):
         path = "tag"
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [core.ApiException("404 tag not found", err), None]
@@ -235,8 +233,7 @@ class TestTagManager(HttpClientTestBase):
 
     def test___tag_not_found__open_with_create_true__creates_tag(self):
         path = "tag"
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [core.ApiException("404 tag not found", err), None]
@@ -302,8 +299,7 @@ class TestTagManager(HttpClientTestBase):
         assert dummy_tag.retention_type == tag.retention_type
 
     def test__tag_not_found__open_with_create_False__raises(self):
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         ex = core.ApiException("404 tag not found", err)
         self._client.all_requests.configure_mock(side_effect=ex)
 
@@ -404,8 +400,7 @@ class TestTagManager(HttpClientTestBase):
 
     @pytest.mark.asyncio
     async def test___tag_not_found__open_async_without_datatype__raises(self):
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         ex = core.ApiException("404 tag not found", err)
         self._client.all_requests.configure_mock(side_effect=ex)
 
@@ -420,8 +415,7 @@ class TestTagManager(HttpClientTestBase):
     @pytest.mark.asyncio
     async def test___tag_not_found__open_async_with_datatype__creates_tag(self):
         path = "tag"
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [core.ApiException("404 tag not found", err), None]
@@ -451,8 +445,7 @@ class TestTagManager(HttpClientTestBase):
     @pytest.mark.asyncio
     async def test___tag_not_found__open_async_with_create_true__creates_tag(self):
         path = "tag"
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [core.ApiException("404 tag not found", err), None]
@@ -520,8 +513,7 @@ class TestTagManager(HttpClientTestBase):
 
     @pytest.mark.asyncio
     async def test__tag_not_found__open_async_with_create_False__raises(self):
-        err = core.ApiError()
-        err.name = "Tag.NoSuchTag"
+        err = core.ApiError(name="Tag.NoSuchTag")
         ex = core.ApiException("404 tag not found", err)
         self._client.all_requests.configure_mock(side_effect=ex)
 
@@ -1384,19 +1376,24 @@ class TestTagManager(HttpClientTestBase):
 
     def test__partial_success__update_with_tags__raises(self):
         path = "invalid"
-        error = core.ApiError()
-        error.name = "Tag.OneOrMoreErrorsOccurred"
-        error.message = "One or more errors occurred"
-        inner_errors = [core.ApiError(), core.ApiError()]
-        inner_errors[0].name = "Tag.InvalidDataType"
-        inner_errors[0].message = "Invalid data type"
-        inner_errors[0].resource_type = "tag"
-        inner_errors[0].resource_id = path
-        inner_errors[1].name = "Tag.Conflict"
-        inner_errors[1].message = "Conflict of some sort"
-        inner_errors[1].resource_type = "tag"
-        inner_errors[1].resource_id = "another"
-        error.inner_errors = inner_errors
+        error = core.ApiError(
+            name="Tag.OneOrMoreErrorsOccurred",
+            message="One or more errors occurred",
+            inner_errors=[
+                core.ApiError(
+                    name="Tag.InvalidDataType",
+                    message="Invalid data type",
+                    resource_type="tag",
+                    resource_id=path,
+                ),
+                core.ApiError(
+                    name="Tag.Conflict",
+                    message="Conflict of some sort",
+                    resource_type="tag",
+                    resource_id="another",
+                ),
+            ],
+        )
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [
@@ -1527,19 +1524,24 @@ class TestTagManager(HttpClientTestBase):
 
     def test__partial_success__update_with_tag_updates__raises(self):
         path = "invalid"
-        error = core.ApiError()
-        error.name = ("Tag.OneOrMoreErrorsOccurred",)
-        error.message = ("One or more errors occurred",)
-        inner_errors = [core.ApiError(), core.ApiError()]
-        inner_errors[0].name = ("Tag.InvalidDataType",)
-        inner_errors[0].message = ("Invalid data type",)
-        inner_errors[0].resource_type = ("tag",)
-        inner_errors[0].resource_id = path
-        inner_errors[1].name = ("Tag.Conflict",)
-        inner_errors[1].message = ("Conflict of some sort",)
-        inner_errors[1].resource_type = ("tag",)
-        inner_errors[1].resource_id = "another"
-        error.inner_errors = inner_errors
+        error = core.ApiError(
+            name="Tag.OneOrMoreErrorsOccurred",
+            message="One or more errors occurred",
+            inner_errors=[
+                core.ApiError(
+                    name="Tag.InvalidDataType",
+                    message="Invalid data type",
+                    resource_type="tag",
+                    resource_id=path,
+                ),
+                core.ApiError(
+                    name="Tag.Conflict",
+                    message="Conflict of some sort",
+                    resource_type="tag",
+                    resource_id="another",
+                ),
+            ],
+        )
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [
@@ -1651,19 +1653,24 @@ class TestTagManager(HttpClientTestBase):
     @pytest.mark.asyncio
     async def test__partial_success__update_async_with_tags__raises(self):
         path = "invalid"
-        error = core.ApiError()
-        error.name = ("Tag.OneOrMoreErrorsOccurred",)
-        error.message = ("One or more errors occurred",)
-        inner_errors = [core.ApiError(), core.ApiError()]
-        inner_errors[0].name = ("Tag.InvalidDataType",)
-        inner_errors[0].message = ("Invalid data type",)
-        inner_errors[0].resource_type = ("tag",)
-        inner_errors[0].resource_id = path
-        inner_errors[1].name = ("Tag.Conflict",)
-        inner_errors[1].message = ("Conflict of some sort",)
-        inner_errors[1].resource_type = ("tag",)
-        inner_errors[1].resource_id = "another"
-        error.inner_errors = inner_errors
+        error = core.ApiError(
+            name="Tag.OneOrMoreErrorsOccurred",
+            message="One or more errors occurred",
+            inner_errors=[
+                core.ApiError(
+                    name="Tag.InvalidDataType",
+                    message="Invalid data type",
+                    resource_type="tag",
+                    resource_id=path,
+                ),
+                core.ApiError(
+                    name="Tag.Conflict",
+                    message="Conflict of some sort",
+                    resource_type="tag",
+                    resource_id="another",
+                ),
+            ],
+        )
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [
@@ -1797,19 +1804,24 @@ class TestTagManager(HttpClientTestBase):
     @pytest.mark.asyncio
     async def test__partial_success__update_async_with_tag_updates__raises(self):
         path = "invalid"
-        error = core.ApiError()
-        error.name = ("Tag.OneOrMoreErrorsOccurred",)
-        error.message = ("One or more errors occurred",)
-        inner_errors = [core.ApiError(), core.ApiError()]
-        inner_errors[0].name = ("Tag.InvalidDataType",)
-        inner_errors[0].message = ("Invalid data type",)
-        inner_errors[0].resource_type = ("tag",)
-        inner_errors[0].resource_id = path
-        inner_errors[1].name = ("Tag.Conflict",)
-        inner_errors[1].message = ("Conflict of some sort",)
-        inner_errors[1].resource_type = ("tag",)
-        inner_errors[1].resource_id = "another"
-        error.inner_errors = inner_errors
+        error = core.ApiError(
+            name="Tag.OneOrMoreErrorsOccurred",
+            message="One or more errors occurred",
+            inner_errors=[
+                core.ApiError(
+                    name="Tag.InvalidDataType",
+                    message="Invalid data type",
+                    resource_type="tag",
+                    resource_id=path,
+                ),
+                core.ApiError(
+                    name="Tag.Conflict",
+                    message="Conflict of some sort",
+                    resource_type="tag",
+                    resource_id="another",
+                ),
+            ],
+        )
         self._client.all_requests.configure_mock(
             side_effect=self._get_mock_request(
                 [


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds `delete_tables` method to remove multiple tables in one call
- Refactors `core.ApiError` to be a Pydantic model so we can nest it in the delete partial success response
- Adds response body de-serialization that can handle Union types
- Adds wrappers around Uplink HTTP method decorators with naive typing to fix mypy errors and make client implementation simpler

### What testing has been done?

- Added automated tests for delete methods
- Automated tag tests should hopefully cover ApiError refactor
