### PR TITLE
Documentation fixes

### DIFF
--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -6,6 +6,8 @@ nisystemlink.clients.dataframe
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
    :members:
 
+   .. automethod:: delete_table(id)
+
 .. automodule:: nisystemlink.clients.dataframe.models
    :members:
    :imported-members:

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -5,7 +5,6 @@ nisystemlink.clients.dataframe
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
    :members:
-   .. automethod:: delete_table(id)
 
 .. automodule:: nisystemlink.clients.dataframe.models
    :members:

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -4,8 +4,8 @@ nisystemlink.clients.dataframe
 ======================
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
+   :special-members: __init__
 
-   .. automethod:: __init__
    .. automethod:: api_info
    .. automethod:: list_tables
    .. automethod:: create_table

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -4,9 +4,8 @@ nisystemlink.clients.dataframe
 ======================
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
-   :members:
 
-   .. automethod:: delete_table(id)
+   .. automethod:: delete_table
 
 .. automodule:: nisystemlink.clients.dataframe.models
    :members:

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -4,8 +4,8 @@ nisystemlink.clients.dataframe
 ======================
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
-   :special-members: __init__
 
+   .. automethod:: __init__
    .. automethod:: api_info
    .. automethod:: list_tables
    .. automethod:: create_table

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -3,9 +3,9 @@
 nisystemlink.clients.dataframe
 ======================
 
-.. automodule:: nisystemlink.clients.dataframe
+.. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
    :members:
-   :imported-members:
+   .. automethod:: delete_table(id)
 
 .. automodule:: nisystemlink.clients.dataframe.models
    :members:

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -5,7 +5,20 @@ nisystemlink.clients.dataframe
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
 
+   .. automethod:: __init__
+   .. automethod:: api_info
+   .. automethod:: list_tables
+   .. automethod:: create_table
+   .. automethod:: query_tables
+   .. automethod:: get_table_metadata
+   .. automethod:: modify_table
    .. automethod:: delete_table
+   .. automethod:: delete_tables
+   .. automethod:: modify_tables
+   .. automethod:: get_table_data
+   .. automethod:: append_table_data
+   .. automethod:: query_table_data
+   .. automethod:: query_decimated_data
 
 .. automodule:: nisystemlink.clients.dataframe.models
    :members:

--- a/docs/api_reference/dataframe.rst
+++ b/docs/api_reference/dataframe.rst
@@ -4,6 +4,7 @@ nisystemlink.clients.dataframe
 ======================
 
 .. autoclass:: nisystemlink.clients.dataframe.DataFrameClient
+   :exclude-members: __init__
 
    .. automethod:: __init__
    .. automethod:: api_info

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ nitpick_ignore = [
     ("py:data", "typing.Union"),
 ]
 autodoc_default_options = {
-    "autoclass_content": "both",
+    "special-members": "__init__",
     "no-private-members": True,
 }
 # Don't let napoleon force methods to be included in the docs; use autodoc flags and our

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ nitpick_ignore = [
     ("py:data", "typing.Union"),
 ]
 autodoc_default_options = {
+    "autoclass_content": "both",
     "no-private-members": True,
 }
 # Don't let napoleon force methods to be included in the docs; use autodoc flags and our

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,6 @@ nitpick_ignore = [
     ("py:data", "typing.Union"),
 ]
 autodoc_default_options = {
-    "special-members": "__init__",
     "no-private-members": True,
 }
 # Don't let napoleon force methods to be included in the docs; use autodoc flags and our

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ User Documentation
 ******************
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    getting_started
    api_reference


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Properly documents methods of `DataFrameClient`
The uplink decorators turns the functions into objects and Sphinx isn't auto documenting them meaningfully, even though the special methods like `__doc__` are preserved.
![image](https://user-images.githubusercontent.com/9257800/206279145-964c0420-e234-4510-9350-8471e63ab031.png)
After some trial and error, I discovered that manually specifying the methods with `automethod::` gets Sphinx to treat the objects like functions and generate the correct docs.

- Reduces the clutter on the index page by reducing the TOC depth

### Why should this Pull Request be merged?

It makes the docs better!

### What testing has been done?

- See the built docs from this PR
