### PR TITLE
fix: Commit message validation

### DIFF
--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -1,6 +1,12 @@
 name: Commit message validation
 
-on: pull_request
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 jobs:
   commit-message-validation:

--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -1,16 +1,12 @@
-name: Commit message validation on PR
+name: Commit message validation
 
 on: pull_request
 
 jobs:
   commit-message-validation:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Commit message validation
-        uses: lumapps/commit-message-validator@master
+        uses: aslafy-z/conventional-pr-title-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -1,0 +1,16 @@
+name: Commit message validation on PR
+
+on: pull_request
+
+jobs:
+  commit-message-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Commit message validation
+        uses: lumapps/commit-message-validator@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds validation that commit messages adhere to the [Angular style](https://gist.github.com/brianclements/841ea7bffdb01346392c).

This commit would generally have a "build" or "ci" prefix type, but we need to force a version and rebuild as https://github.com/ni/nisystemlink-clients-python/commit/7881a90c7fcfc5dd88228d171f8000b10330b04f did not result in a new version being built.

### Why should this Pull Request be merged?

Ensure we have properly formatted commit messages.

### What testing has been done?

See PR build.
