### PR TITLE
chore: Pin python-semantic-release to latest 7.x version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,7 @@ jobs:
       - run: poetry install
       - name: Semantic release
         run: |
-          pip install python-semantic-release
+          pip install python-semantic-release==7.34.6
           git config --global user.name "github-actions"
           git config --global user.email "action@github.com"
           semantic-release publish


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Pin the version of python-semantic-release to 7.34.3, which is the latest 7.x release. The 8.x releases [drastically changed](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html) how the utility is used.

### Why should this Pull Request be merged?

Fix our release workflow so we can actually publish new versions (AB#2468953).

### What testing has been done?

Verified the pip install command works. No other testing.