### PR TITLE
feat: test monitor API information routes client

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -9,6 +9,7 @@ API Reference
 
    api_reference/core
    api_reference/tag
+   api_reference/testmonitor
    api_reference/dataframe
    api_reference/spec
 

--- a/docs/api_reference/testmonitor.rst
+++ b/docs/api_reference/testmonitor.rst
@@ -1,0 +1,13 @@
+.. _api_tag_page:
+
+nisystemlink.clients.testmonitor
+======================
+
+.. autoclass:: nisystemlink.clients.testmonitor.TestMonitorClient
+   :exclude-members: __init__
+
+   .. automethod:: __init__
+
+.. automodule:: nisystemlink.clients.testmonitor.models
+   :members:
+   :imported-members:

--- a/nisystemlink/clients/testmonitor/__init__.py
+++ b/nisystemlink/clients/testmonitor/__init__.py
@@ -1,0 +1,1 @@
+from ._test_monitor_client import TestMonitorClient

--- a/nisystemlink/clients/testmonitor/__init__.py
+++ b/nisystemlink/clients/testmonitor/__init__.py
@@ -1,1 +1,3 @@
 from ._test_monitor_client import TestMonitorClient
+
+# flake8: noqa

--- a/nisystemlink/clients/testmonitor/_test_monitor_client.py
+++ b/nisystemlink/clients/testmonitor/_test_monitor_client.py
@@ -13,10 +13,10 @@ class TestMonitorClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration]):
         if configuration is None:
             configuration = core.JupyterHttpConfiguration()
-        super.__init__(configuration, base_path="/nitestmonitor/v2/")
+        super().__init__(configuration, base_path="/nitestmonitor/v2/")
 
     @get("")
-    def api_info(self) -> models.V2Operations:
+    def api_info(self) -> models.ApiInfo:
         """Get information about the available API operations.
 
         Returns:

--- a/nisystemlink/clients/testmonitor/_test_monitor_client.py
+++ b/nisystemlink/clients/testmonitor/_test_monitor_client.py
@@ -1,0 +1,28 @@
+"""Implementation of TestMonitor Client"""
+
+from typing import List, Optional
+
+from nisystemlink.clients import core
+from nisystemlink.clients.core._uplink._base_client import BaseClient
+from nisystemlink.clients.core._uplink._methods import get, post
+
+from . import models
+
+
+class TestMonitorClient(BaseClient):
+    def __init__(self, configuration: Optional[core.HttpConfiguration]):
+        if configuration is None:
+            configuration = core.JupyterHttpConfiguration()
+        super.__init__(configuration, base_path="/nitestmonitor/v2/")
+
+    @get("")
+    def api_info(self) -> models.V2Operations:
+        """Get information about the available API operations.
+
+        Returns:
+            Information about available API operations.
+
+        Raises:
+            ApiException: if unable to communicate with the `nitestmonitor` service.
+        """
+        ...

--- a/nisystemlink/clients/testmonitor/_test_monitor_client.py
+++ b/nisystemlink/clients/testmonitor/_test_monitor_client.py
@@ -1,10 +1,10 @@
 """Implementation of TestMonitor Client"""
 
-from typing import List, Optional
+from typing import Optional
 
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
-from nisystemlink.clients.core._uplink._methods import get, post
+from nisystemlink.clients.core._uplink._methods import get
 
 from . import models
 

--- a/nisystemlink/clients/testmonitor/models/__init__.py
+++ b/nisystemlink/clients/testmonitor/models/__init__.py
@@ -1,0 +1,1 @@
+from ._api_info import Operation, V2Operations

--- a/nisystemlink/clients/testmonitor/models/__init__.py
+++ b/nisystemlink/clients/testmonitor/models/__init__.py
@@ -1,1 +1,3 @@
 from ._api_info import Operation, V2Operations, ApiInfo
+
+# flake8: noqa

--- a/nisystemlink/clients/testmonitor/models/__init__.py
+++ b/nisystemlink/clients/testmonitor/models/__init__.py
@@ -1,1 +1,1 @@
-from ._api_info import Operation, V2Operations
+from ._api_info import Operation, V2Operations, ApiInfo

--- a/nisystemlink/clients/testmonitor/models/_api_info.py
+++ b/nisystemlink/clients/testmonitor/models/_api_info.py
@@ -9,7 +9,7 @@ class V2Operations(JsonModel):
     """The ability to get a list of products."""
 
     query_products: Operation
-    """The ability to query Products based on their properties."""
+    """The ability to query products based on their properties."""
 
     create_products: Operation
     """The ability to create one or more products."""

--- a/nisystemlink/clients/testmonitor/models/_api_info.py
+++ b/nisystemlink/clients/testmonitor/models/_api_info.py
@@ -5,27 +5,68 @@ from nisystemlink.clients.core._uplink._json_model import JsonModel
 class V2Operations(JsonModel):
     """The operations available in the routes provided by the v2 HTTP API."""
 
-    get_results: Operation
-    get_results_property_keys: Operation
-    query_results: Operation
-    create_results: Operation
-    update_results: Operation
-    delete_result: Operation
-    delete_many_results: Operation
-    get_steps: Operation
-    query_steps: Operation
-    create_steps: Operation
-    update_steps: Operation
-    delete_step: Operation
-    delete_many_steps: Operation
     get_products: Operation
+    """The ability to get a list of products."""
+
     query_products: Operation
+    """The ability to query Products based on their properties."""
+
     create_products: Operation
+    """The ability to create one or more products."""
+
     update_products: Operation
+    """The ability to update the properties of one or more products."""
+
     delete_products: Operation
+    """The ability to delete a single products."""
+
     delete_many_products: Operation
+    """The ability to delete a list of products."""
+
+    get_results: Operation
+    """The ability to get a list of results."""
+
+    get_results_property_keys: Operation
+    """The ability to get custom property keys."""
+
+    query_results: Operation
+    """"The ability to to query results based on their properties."""
+
+    create_results: Operation
+    """The ability to create results."""
+
+    update_results: Operation
+    """The ability to update results."""
+
+    delete_result: Operation
+    """The ability to delete a single results."""
+
+    delete_many_results: Operation
+    """The ability to delete multiple results."""
+
+    get_steps: Operation
+    """The ability to get a list of steps."""
+
+    query_steps: Operation
+    """The ability to query steps based on their properties."""
+
+    create_steps: Operation
+    """The ability to create steps."""
+
+    update_steps: Operation
+    """The ability to update steps."""
+
+    delete_step: Operation
+    """The ability to delete a single step."""
+
+    delete_many_steps: Operation
+    """The ability to delete multiple steps."""
+
     query_paths: Operation
+    """The ability to query step paths."""
 
 
 class ApiInfo(JsonModel):
+    """Information about the available API operations."""
+
     operations: V2Operations

--- a/nisystemlink/clients/testmonitor/models/_api_info.py
+++ b/nisystemlink/clients/testmonitor/models/_api_info.py
@@ -25,3 +25,7 @@ class V2Operations(JsonModel):
     delete_products: Operation
     delete_many_products: Operation
     query_paths: Operation
+
+
+class ApiInfo(JsonModel):
+    operations: V2Operations

--- a/nisystemlink/clients/testmonitor/models/_api_info.py
+++ b/nisystemlink/clients/testmonitor/models/_api_info.py
@@ -1,0 +1,27 @@
+from nisystemlink.clients.core._api_info import Operation
+from nisystemlink.clients.core._uplink._json_model import JsonModel
+
+
+class V2Operations(JsonModel):
+    """The operations available in the routes provided by the v2 HTTP API."""
+
+    get_results: Operation
+    get_results_property_keys: Operation
+    query_results: Operation
+    create_results: Operation
+    update_results: Operation
+    delete_result: Operation
+    delete_many_results: Operation
+    get_steps: Operation
+    query_steps: Operation
+    create_steps: Operation
+    update_steps: Operation
+    delete_step: Operation
+    delete_many_steps: Operation
+    get_products: Operation
+    query_products: Operation
+    create_products: Operation
+    update_products: Operation
+    delete_products: Operation
+    delete_many_products: Operation
+    query_paths: Operation

--- a/tests/integration/testmonitor/__init__.py
+++ b/tests/integration/testmonitor/__init__.py
@@ -1,0 +1,1 @@
+# flake8: noqa

--- a/tests/integration/testmonitor/test_products.py
+++ b/tests/integration/testmonitor/test_products.py
@@ -5,7 +5,7 @@ from nisystemlink.clients.testmonitor import TestMonitorClient
 
 @pytest.fixture(scope="class")
 def client(enterprise_config: HttpConfiguration) -> TestMonitorClient:
-    """Fixture to create a SpecClient instance."""
+    """Fixture to create a TestMonitorClient instance."""
     return TestMonitorClient(enterprise_config)
 
 

--- a/tests/integration/testmonitor/test_products.py
+++ b/tests/integration/testmonitor/test_products.py
@@ -1,0 +1,17 @@
+import pytest
+from nisystemlink.clients.core._http_configuration import HttpConfiguration
+from nisystemlink.clients.testmonitor import TestMonitorClient
+
+
+@pytest.fixture(scope="class")
+def client(enterprise_config: HttpConfiguration) -> TestMonitorClient:
+    """Fixture to create a SpecClient instance."""
+    return TestMonitorClient(enterprise_config)
+
+
+@pytest.mark.integration
+@pytest.mark.enterprise
+class TestTestMonitor:
+    def test__api_info__returns(self, client: TestMonitorClient):
+        response = client.api_info()
+        assert len(response.dict()) != 0


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds support for the `/nitestmonitor/v2` API info routes. 
I am intentionally leaving out examples for now until we have more interesting examples to write.

### Why should this Pull Request be merged?

This is the first pieces of a broader effort to support the `/nitestmonitor/v2` client.

### What testing has been done?

Auto testing against a SLE instance has been added. 
