### PR TITLE
feat: Make DataFrame and Spec clients compatible with SystemLink Client http configuration

### DIFF
--- a/nisystemlink/clients/core/_http_configuration_manager.py
+++ b/nisystemlink/clients/core/_http_configuration_manager.py
@@ -109,7 +109,9 @@ class HttpConfigurationManager:
         configurations = {}  # type: Dict[str, core.HttpConfiguration]
 
         try:
-            configurations[cls.JUPYTER_HUB_CONFIGURATION_ID] = core.JupyterHttpConfiguration()
+            configurations[
+                cls.JUPYTER_HUB_CONFIGURATION_ID
+            ] = core.JupyterHttpConfiguration()
         except KeyError:
             pass
 

--- a/nisystemlink/clients/core/_http_configuration_manager.py
+++ b/nisystemlink/clients/core/_http_configuration_manager.py
@@ -23,6 +23,9 @@ class HttpConfigurationManager:
     HTTP_LOCALHOST_CONFIGURATION_ID = "SYSTEMLINK_LOCALHOST"
     """The default ID of the SystemLink Server's configuration on the SystemLink Server itself."""
 
+    JUPYTER_HUB_CONFIGURATION_ID = "SYSTEMLINK_JUPYTER_HUB"
+    """ID for the http configuration for Jupyter Notebooks run in a SystemLink Enterprise environment."""
+
     _configs = None
 
     @classmethod
@@ -84,6 +87,9 @@ class HttpConfigurationManager:
         localhost_config = cls._configs.get(cls.HTTP_LOCALHOST_CONFIGURATION_ID)
         if localhost_config is not None:
             return localhost_config
+        jupyter_config = cls._configs.get(cls.JUPYTER_HUB_CONFIGURATION_ID)
+        if jupyter_config is not None:
+            return jupyter_config
         return None
 
     @classmethod
@@ -101,6 +107,12 @@ class HttpConfigurationManager:
                 that contains HTTP configurations.
         """
         configurations = {}  # type: Dict[str, core.HttpConfiguration]
+
+        try:
+            configurations[cls.JUPYTER_HUB_CONFIGURATION_ID] = core.JupyterHttpConfiguration()
+        except KeyError:
+            pass
+
         path = cls._http_configurations_directory()
         if not path.exists():
             return configurations

--- a/nisystemlink/clients/core/_http_configuration_manager.py
+++ b/nisystemlink/clients/core/_http_configuration_manager.py
@@ -109,9 +109,9 @@ class HttpConfigurationManager:
         configurations = {}  # type: Dict[str, core.HttpConfiguration]
 
         try:
-            configurations[
-                cls.JUPYTER_HUB_CONFIGURATION_ID
-            ] = core.JupyterHttpConfiguration()
+            configurations[cls.JUPYTER_HUB_CONFIGURATION_ID] = (
+                core.JupyterHttpConfiguration()
+            )
         except KeyError:
             pass
 

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -24,15 +24,15 @@ class DataFrameClient(BaseClient):
 
         Args:
             configuration: Defines the web server to connect to and information about
-                how to connect. If not provided, an instance of
-                :class:`JupyterHttpConfiguration <nisystemlink.clients.core.JupyterHttpConfiguration>`
-                is used.
+                how to connect. If not provided, the
+                :class:`HttpConfigurationManager <nisystemlink.clients.core.HttpConfigurationManager>`
+                is used to obtain the configuration.
 
         Raises:
             ApiException: if unable to communicate with the DataFrame Service.
         """
         if configuration is None:
-            configuration = core.JupyterHttpConfiguration()
+            configuration = core.HttpConfigurationManager.get_configuration()
 
         super().__init__(configuration, "/nidataframe/v1/")
 

--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -12,8 +12,20 @@ from . import models
 
 class SpecClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration]):
+        """Initialize an instance.
+
+        Args:
+            configuration: Defines the web server to connect to and information about
+                how to connect. If not provided, the
+                :class:`HttpConfigurationManager <nisystemlink.clients.core.HttpConfigurationManager>`
+                is used to obtain the configuration.
+
+        Raises:
+            ApiException: if unable to communicate with the Spec Service.
+        """
         if configuration is None:
-            configuration = core.JupyterHttpConfiguration()
+            configuration = core.HttpConfigurationManager.get_configuration()
+
         super().__init__(configuration, base_path="/nispec/v1/")
 
     @get("")


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `JupyterHttpConfiguration` as a fallback configuration for the `HttpConfigurationManager`. Allows the Clients to authenticate agnostic of the environment they're run from.

### Why should this Pull Request be merged?

Enables SystemLink clients to adapt to supported run environments when using the default value for `configuration` arg like `client = DataFrameClient()`

### What testing has been done?

Manual testing

- Run https://github.com/ni/nisystemlink-clients-python/blob/master/examples/dataframe/export_data.py on the computer with SystemLink Client connected with an SLE server
- `KeyError` occurs because `JupyterHttpConfiguration` is not available outside SLE
- Update the `DataFrameClient()` to use `core.HttpConfigurationManager.get_configuration()` as the default configuration
- Run the example, now, there should be no `KeyError` signifying that the client was created using the SystemLink client's HTTP Credentials
