### PR TITLE
fix: Make SpecClient() work with default values for optional args

### DIFF
--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -11,7 +11,7 @@ from . import models
 
 
 class SpecClient(BaseClient):
-    def __init__(self, configuration: Optional[core.HttpConfiguration]):
+    def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.
 
         Args:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix the bug where the `SpecClient()` result in error though the arg `configuration` is optional.

### Why should this Pull Request be merged?

Enable users use `SpecClient()`  when run in SLE Jupyter executions or with SystemLink Client without passing an `HttpConfiguration` except for elevated privilege.

### What testing has been done?

Run integration tests

Test using a simple spec query example on local machine with SystemLink Client connected to a SLE instance with valid specs.

```py
from nisystemlink.clients.spec import SpecClient
from nisystemlink.clients.spec.models import QuerySpecificationsRequest

client = SpecClient()

product_id = "e1ed79db-2d05-466b-a6d8-9872ec5cee54"
query_request = QuerySpecificationsRequest(product_ids=[product_id])

specs = client.query_specs(query_request)

print(specs.specs)
```
