### PR TITLE
fix: Remove SL Cloud from readme and add SLE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,7 @@ Requirements
 ============
 **nisystemlink-clients** has the following requirements:
 
-* A SystemLink Server installation or a
-  `SystemLink Cloud <https://www.systemlinkcloud.com/>`_ account to connect to
+* Access to a SystemLink Server or SystemLink Enterprise installation
 * CPython 3.9+
 
 .. _installation_section:


### PR DESCRIPTION
remove reference to SystemLink Cloud
add reference to SystemLink Enterprise

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

correcting references to old and new SL products

### Why should this Pull Request be merged?

correcting documentation

### What testing has been done?

just documentation changes, no testing needed
