### PR TITLE
feat: handle rate limiter code 429 by back-off retry

### DIFF
--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -13,11 +13,12 @@ from nisystemlink.clients.core._uplink._methods import (
 )
 from nisystemlink.clients.core.helpers import IteratorFileLike
 from requests.models import Response
-from uplink import Body, Field, Path, Query
+from uplink import Body, Field, Path, Query, retry
 
 from . import models
 
 
+@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 class DataFrameClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Implement a basic back-off retry method for `DataFrameClient` to handle status code 429 by the rate limiter.

### Why should this Pull Request be merged?

Simplify user-side handling for http status code 429

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
