### PR TITLE
test: Stabilize FeedsClient integration tests

### DIFF
--- a/nisystemlink/clients/feeds/_feeds_client.py
+++ b/nisystemlink/clients/feeds/_feeds_client.py
@@ -5,11 +5,12 @@ from typing import BinaryIO, List, Optional
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
 from nisystemlink.clients.core._uplink._methods import delete, get, post
-from uplink import Part, Path, Query
+from uplink import Part, Path, Query, retry
 
 from . import models
 
 
+@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 class FeedsClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.

--- a/nisystemlink/clients/feeds/_feeds_client.py
+++ b/nisystemlink/clients/feeds/_feeds_client.py
@@ -5,12 +5,11 @@ from typing import BinaryIO, List, Optional
 from nisystemlink.clients import core
 from nisystemlink.clients.core._uplink._base_client import BaseClient
 from nisystemlink.clients.core._uplink._methods import delete, get, post
-from uplink import Part, Path, Query, retry
+from uplink import Part, Path, Query
 
 from . import models
 
 
-@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 class FeedsClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -1,7 +1,5 @@
 """Integration tests for FeedsClient."""
 
-import random
-import string
 import uuid
 from pathlib import Path
 from random import randint
@@ -11,7 +9,6 @@ import pytest
 from nisystemlink.clients.core import ApiException
 from nisystemlink.clients.feeds import FeedsClient
 from nisystemlink.clients.feeds.models import CreateFeedRequest, Platform
-from uplink import retry
 
 FEED_DESCRIPTION = "Sample feed for uploading packages"
 PACKAGE_PATH = str(
@@ -23,7 +20,6 @@ PREFIX = "Feeds Client Test - "
 
 
 @pytest.fixture(scope="class")
-@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 def client(enterprise_config) -> FeedsClient:
     """Fixture to create a FeedsClient instance."""
     return FeedsClient(enterprise_config)
@@ -80,10 +76,8 @@ def get_feed_name():
     """Generate a feed name."""
 
     def _get_feed_name():
-
-        first_char = random.choice(string.ascii_letters)
         uuid_part = uuid.uuid4().hex
-        feed_name = f"{PREFIX}{first_char}{uuid_part}"
+        feed_name = f"{PREFIX}{uuid_part}"
 
         return feed_name
 

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -1,5 +1,7 @@
 """Integration tests for FeedsClient."""
 
+import random
+import string
 import uuid
 from pathlib import Path
 from random import randint
@@ -9,7 +11,6 @@ import pytest
 from nisystemlink.clients.core import ApiException
 from nisystemlink.clients.feeds import FeedsClient
 from nisystemlink.clients.feeds.models import CreateFeedRequest, Platform
-
 
 FEED_DESCRIPTION = "Sample feed for uploading packages"
 PACKAGE_PATH = str(
@@ -76,7 +77,13 @@ def get_feed_name():
     """Generate a feed name."""
 
     def _get_feed_name():
-        feed_name = uuid.uuid1().hex[:255]
+
+        first_char = random.choice(string.ascii_letters)
+        uuid_part = uuid.uuid4().hex
+        allowed_chars = string.ascii_letters + string.digits + " _-"
+        filtered_uuid = "".join(char for char in uuid_part if char in allowed_chars)
+
+        feed_name = f"{first_char}{filtered_uuid}"
         return feed_name
 
     yield _get_feed_name

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -19,7 +19,7 @@ PACKAGE_PATH = str(
     / "test_files"
     / "sample-measurement_0.5.0_windows_x64.nipkg"
 )
-PREFIX = "Feeds Client Test -"
+PREFIX = "Feeds Client Test - "
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -80,10 +80,8 @@ def get_feed_name():
 
         first_char = random.choice(string.ascii_letters)
         uuid_part = uuid.uuid4().hex
-        allowed_chars = string.ascii_letters + string.digits + " _-"
-        filtered_uuid = "".join(char for char in uuid_part if char in allowed_chars)
+        feed_name = f"{first_char}{uuid_part}"
 
-        feed_name = f"{first_char}{filtered_uuid}"
         return feed_name
 
     yield _get_feed_name

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -1,5 +1,6 @@
 """Integration tests for FeedsClient."""
 
+import uuid
 from pathlib import Path
 from random import randint
 from typing import BinaryIO, Callable
@@ -73,13 +74,9 @@ def invalid_id() -> str:
 @pytest.fixture(scope="class")
 def get_feed_name():
     """Generate a feed name."""
-    name = "testfeed_"
-    feed_count = 0
 
     def _get_feed_name():
-        nonlocal feed_count
-        feed_count += 1
-        feed_name = name + str(feed_count)
+        feed_name = uuid.uuid1().hex[:255]
         return feed_name
 
     yield _get_feed_name

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -11,6 +11,7 @@ import pytest
 from nisystemlink.clients.core import ApiException
 from nisystemlink.clients.feeds import FeedsClient
 from nisystemlink.clients.feeds.models import CreateFeedRequest, Platform
+from uplink import retry
 
 FEED_DESCRIPTION = "Sample feed for uploading packages"
 PACKAGE_PATH = str(
@@ -22,6 +23,7 @@ PREFIX = "Feeds Client Test -"
 
 
 @pytest.fixture(scope="class")
+@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 def client(enterprise_config) -> FeedsClient:
     """Fixture to create a FeedsClient instance."""
     return FeedsClient(enterprise_config)

--- a/tests/integration/feeds/test_feeds_client.py
+++ b/tests/integration/feeds/test_feeds_client.py
@@ -18,6 +18,7 @@ PACKAGE_PATH = str(
     / "test_files"
     / "sample-measurement_0.5.0_windows_x64.nipkg"
 )
+PREFIX = "Feeds Client Test -"
 
 
 @pytest.fixture(scope="class")
@@ -80,7 +81,7 @@ def get_feed_name():
 
         first_char = random.choice(string.ascii_letters)
         uuid_part = uuid.uuid4().hex
-        feed_name = f"{first_char}{uuid_part}"
+        feed_name = f"{PREFIX}{first_char}{uuid_part}"
 
         return feed_name
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Fix the `DuplicateFeedsError` by updating the feedname generation in the tests.
- Fix the `MultipleRequestError` by adding retry decorator to `FeedsClient`.

### Why should this Pull Request be merged?

Enable users to use FeedsClient without any issues.

### What testing has been done?

Auto testing is included against NI's test tier.
[Swagger API Link](https://dev-api.lifecyclesolutions.ni.com/ninbexecution/swagger/index.html?urls.primaryName=Notebook+Execution+Artifact+Service)