### PR TITLE
fix: Enable null value for results properties

### DIFF
--- a/nisystemlink/clients/testmonitor/models/_create_result_request.py
+++ b/nisystemlink/clients/testmonitor/models/_create_result_request.py
@@ -35,7 +35,7 @@ class CreateResultRequest(JsonModel):
     keywords: Optional[List[str]]
     """A list of keywords that categorize this result."""
 
-    properties: Optional[Dict[str, str]]
+    properties: Optional[Dict[str, Optional[str]]]
     """A list of custom properties for this result."""
 
     operator: Optional[str]

--- a/nisystemlink/clients/testmonitor/models/_result.py
+++ b/nisystemlink/clients/testmonitor/models/_result.py
@@ -42,7 +42,7 @@ class Result(JsonModel):
     keywords: Optional[List[str]]
     """A list of keywords that categorize this result."""
 
-    properties: Optional[Dict[str, str]]
+    properties: Optional[Dict[str, Optional[str]]]
     """A list of custom properties for this result."""
 
     operator: Optional[str]

--- a/nisystemlink/clients/testmonitor/models/_update_result_request.py
+++ b/nisystemlink/clients/testmonitor/models/_update_result_request.py
@@ -38,7 +38,7 @@ class UpdateResultRequest(JsonModel):
     keywords: Optional[List[str]]
     """A list of keywords that categorize this result."""
 
-    properties: Optional[Dict[str, str]]
+    properties: Optional[Dict[str, Optional[str]]]
     """A list of custom properties for this result."""
 
     operator: Optional[str]

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -122,7 +122,10 @@ class TestTestMonitor:
         status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status, properties={"test": None}
+                part_number=unique_identifier,
+                program_name=program_name,
+                status=status,
+                properties={"test": None},
             )
         ]
         create_results(results)

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import Dict, List, Optional
 
 import pytest
 from nisystemlink.clients.core._http_configuration import HttpConfiguration
@@ -321,7 +321,7 @@ class TestTestMonitor:
         original_properties = {"originalKey": "originalValue"}
         program_name = "Test Program"
         status = Status.PASSED()
-        new_properties = {new_key: "newValue"}
+        new_properties: Dict[str, Optional[str]] = {new_key: "newValue"}
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(
@@ -358,7 +358,7 @@ class TestTestMonitor:
         original_properties = {original_key: "originalValue"}
         program_name = "Test Program"
         status = Status.PASSED()
-        new_properties = {new_key: "newValue"}
+        new_properties: Dict[str, Optional[str]] = {new_key: "newValue"}
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -122,7 +122,7 @@ class TestTestMonitor:
         status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status
+                part_number=unique_identifier, program_name=program_name, status=status, properties={"test": None}
             )
         ]
         create_results(results)


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Test results can be created with `null` for `properties` value. eg. {"author": null}. The [PR](https://github.com/ni/nisystemlink-clients-python/pull/82) merge pipeline is failing while querying such results from the test env. To accommodate this, the results client has been modified to accept Optional value for properties.

### Why should this Pull Request be merged?

Pipeline failure - [link](https://github.com/ni/nisystemlink-clients-python/actions/runs/13671574503/job/38222758606)

### What testing has been done?

Ran automated tests against dev and test env
