### PR TITLE
feat: Export steps as dataframe

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -254,7 +254,7 @@ Delete a feed.
    :language: python
    :linenos:
 
-TestMonitor API (Results)
+TestMonitor API (Results and Steps)
 -------
 
 Overview

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,7 +1,7 @@
 from ._dataframe_utilities import (
     convert_results_to_dataframe,
     convert_steps_to_dataframe,
-    is_valid_measurement,
+    is_step_data_with_name_and_measurement,
 )
 
 # flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,0 +1,3 @@
+from ._dataframe_utilities import convert_steps_to_dataframe
+
+# flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,6 +1,7 @@
 from ._dataframe_utilities import (
     convert_results_to_dataframe,
     convert_steps_to_dataframe,
+    is_default_measurement_data_parameter,
 )
 
 # flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,7 +1,7 @@
 from ._dataframe_utilities import (
     convert_results_to_dataframe,
     convert_steps_to_dataframe,
-    is_default_measurement_data_parameter,
+    is_step_data_with_name_and_measurement,
 )
 
 # flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,7 +1,7 @@
 from ._dataframe_utilities import (
     convert_results_to_dataframe,
     convert_steps_to_dataframe,
-    is_step_data_with_name_and_measurement,
+    is_valid_measurement,
 )
 
 # flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/__init__.py
+++ b/nisystemlink/clients/testmonitor/utilities/__init__.py
@@ -1,7 +1,7 @@
 from ._dataframe_utilities import (
     convert_results_to_dataframe,
     convert_steps_to_dataframe,
-    is_step_data_with_name_and_measurement,
+    has_name_and_measurement,
 )
 
 # flake8: noqa

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -10,7 +10,7 @@ from nisystemlink.clients.testmonitor.models import (
 from nisystemlink.clients.testmonitor.utilities.constants import DataFrameHeaders
 
 
-def is_valid_measurement(measurement: Measurement) -> bool:
+def is_step_data_with_name_and_measurement(measurement: Measurement) -> bool:
     """Checks if a step data parameter is measurement data by ensuring it has both
     'name' and 'measurement' fields.
 
@@ -60,7 +60,7 @@ def convert_steps_to_dataframe(
     steps: List[Step],
     is_valid_measurement: Optional[
         Callable[[Measurement], bool]
-    ] = is_valid_measurement,
+    ] = is_step_data_with_name_and_measurement,
 ) -> pd.DataFrame:
     """Converts a list of steps into a normalized dataframe.
 

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -11,7 +11,8 @@ from nisystemlink.clients.testmonitor.utilities.constants import DataFrameHeader
 
 
 def is_step_data_with_name_and_measurement(measurement: Measurement) -> bool:
-    """Checks if a measurement data has both 'name' and 'measurement' fields.
+    """Checks if a step data parameter is measurement data by ensuring it has both
+    'name' and 'measurement' fields.
 
     Args:
         measurement: A measurement data object

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -1,0 +1,132 @@
+from typing import Any, Dict, List
+
+import pandas as pd
+from nisystemlink.clients.testmonitor.models import (
+    Step,
+    StepProjection,
+)
+from pandas import DataFrame
+
+
+def convert_steps_to_dataframe(steps: List[Step]) -> DataFrame:
+    """Converts a list of steps into a normalized dataframe.
+
+    - A new column would be created for unique `properties` across all steps. The property
+    columns would be named in the format `properties.property_name`.
+    - `Inputs` and `Outputs` are converted from a list of name-value pairs to a dict and then
+    normalized - similar to properties.
+    - For each `parameter` entry in `data`, a new row is added in the dataframe, with all the
+    other values are duplicated.
+
+    Args:
+        steps: A list of steps.
+
+    Returns:
+        DataFrame:
+            - A Pandas DataFrame containing the steps data. The DataFrame would consist of all the
+            fields in the input steps.
+            - A new column would be created for unique `properties` across all steps. The property
+            columns would be named in the format `properties.property_name`.
+            - `Inputs` and `Outputs` are converted from a list of name-value pairs to a dict and then
+            normalized - similar to properties.
+            - For each `parameter` entry in `data`, a new row is added in the dataframe, with all the
+            other values are duplicated.
+    """
+    DATA_PARAMETERS = "data.parameters"
+
+    restructured_steps = __restructure_steps(steps)
+
+    # checking if `data` exists in the steps. the following logic is specific to process `data` field
+    if steps and steps[0].data:
+        steps_dataframe = pd.json_normalize(restructured_steps, sep=".").explode(
+            DATA_PARAMETERS, ignore_index=True
+        )
+        steps_dataframe = pd.concat(
+            [
+                steps_dataframe.drop(columns=[DATA_PARAMETERS]),
+                pd.json_normalize(steps_dataframe[DATA_PARAMETERS]).add_prefix(
+                    f"{DATA_PARAMETERS}."
+                ),
+            ],
+            axis=1,
+        )
+    else:
+        steps_dataframe = pd.json_normalize(restructured_steps, sep=".")
+
+    grouped_columns = __group_step_columns(steps_dataframe.columns)
+
+    return steps_dataframe.reindex(columns=grouped_columns)
+
+
+def __restructure_steps(steps: List[Step]) -> List[Dict[str, Any]]:
+    """Restructures a list of step responses by converting input and output lists into dictionaries.
+
+    Each dictionary maps input/output names to their corresponding values, making it easier to
+    normalize the data into a DataFrame. Without this transformation, inputs and outputs would
+    remain as lists within a single cell.
+
+    Args:
+        steps: A list of step responses retrieved from the API.
+
+    Returns:
+        List[Step]: Restructured steps - modification involves the conversion of list of inputs and outputs
+        into dictionaries respectively.
+    """
+    restructured_steps = []
+
+    for step in steps:
+        step_dict = step.dict(exclude_none=True)
+        step_dict[StepProjection.INPUTS.lower()] = (
+            {item.name: item.value for item in step.inputs} if step.inputs else {}
+        )
+        step_dict[StepProjection.OUTPUTS.lower()] = (
+            {item.name: item.value for item in step.outputs} if step.outputs else {}
+        )
+
+        restructured_steps.append(step_dict)
+
+    return restructured_steps
+
+
+def __group_step_columns(df_columns: List[str]) -> List[str]:
+    """Groups and orders dataframe columns into predefined categories to maintain a consistent structure.
+
+    When normalizing steps into a dataframe, new input, output, or property fields may be added at the end,
+    disrupting the expected column order. This function ensures columns are grouped properly.
+
+    Args:
+        df_columns: The list of all columns from the normalized dataframe.
+
+    Returns:
+        List[str]: A list containing grouped and ordered columns.
+    """
+    GENERAL_CATEGORIES = "general"
+    CATEGORY_KEYS = [
+        GENERAL_CATEGORIES,
+        StepProjection.INPUTS,
+        StepProjection.OUTPUTS,
+        StepProjection.DATA,
+        StepProjection.PROPERTIES,
+    ]
+
+    grouped_columns: Dict[str, List[str]] = {category: [] for category in CATEGORY_KEYS}
+
+    for column in df_columns:
+        column_lower = column.lower()
+        if (
+            StepProjection.DATA.lower() in column_lower
+            and column != StepProjection.DATA_MODEL.lower()
+        ):
+            grouped_columns[StepProjection.DATA].append(column)
+        elif StepProjection.INPUTS.lower() in column_lower:
+            grouped_columns[StepProjection.INPUTS].append(column)
+        elif StepProjection.OUTPUTS.lower() in column_lower:
+            grouped_columns[StepProjection.OUTPUTS].append(column)
+        elif StepProjection.PROPERTIES.lower() in column_lower:
+            grouped_columns[StepProjection.PROPERTIES].append(column)
+        else:
+            grouped_columns[GENERAL_CATEGORIES].append(column)
+
+    return [
+        column for category in CATEGORY_KEYS for column in grouped_columns[category]
+    ]

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -202,7 +202,7 @@ def __normalize_inputs_outputs(
 def __normalize_step_status(step_dict: Dict[str, Any]) -> None:
     step_status = step_dict.get("status", {})
     if step_status.get("status_type") == "CUSTOM":
-        step_dict["status"] = step_status["status_name"]
+        step_dict["status"] = step_status.get("status_name", None)
     else:
         step_dict["status"] = step_status["status_type"].value
 

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -259,8 +259,11 @@ def __normalize_inputs_outputs(
 
 def __normalize_step_status(step_dict: Dict[str, Any]) -> None:
     step_status = step_dict.get("status", {})
-    step_dict["status"] = step_status.get("status_name", None) if step_status.get(
-        "status_type") == "CUSTOM" else step_status["status_type"].value
+    step_dict["status"] = (
+        step_status.get("status_name", None)
+        if step_status.get("status_type") == "CUSTOM"
+        else step_status["status_type"].value
+    )
 
 
 def __explode_and_normalize(

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -36,26 +36,47 @@ def convert_steps_to_dataframe(steps: List[Step]) -> DataFrame:
 
     restructured_steps = __restructure_steps(steps)
 
-    # checking if `data` exists in the steps. the following logic is specific to process `data` field
-    if steps and steps[0].data:
-        steps_dataframe = pd.json_normalize(restructured_steps, sep=".").explode(
-            DATA_PARAMETERS, ignore_index=True
+    steps_dataframe = pd.json_normalize(restructured_steps, sep=".")
+    if DATA_PARAMETERS in steps_dataframe.columns.to_list():
+        steps_dataframe = __explode_and_normalize(
+            steps_dataframe, DATA_PARAMETERS, f"{DATA_PARAMETERS}."
         )
-        steps_dataframe = pd.concat(
-            [
-                steps_dataframe.drop(columns=[DATA_PARAMETERS]),
-                pd.json_normalize(steps_dataframe[DATA_PARAMETERS]).add_prefix(
-                    f"{DATA_PARAMETERS}."
-                ),
-            ],
-            axis=1,
-        )
-    else:
-        steps_dataframe = pd.json_normalize(restructured_steps, sep=".")
 
     grouped_columns = __group_step_columns(steps_dataframe.columns)
 
     return steps_dataframe.reindex(columns=grouped_columns)
+
+
+def __explode_and_normalize(
+    dataframe: DataFrame, column: str, prefix: str
+) -> DataFrame:
+    """Explodes a specified column in the dataframe and normalizes its nested data.
+
+    This function handles the process of exploding a column that contains lists or arrays,
+    transforming each list element into a separate row. After exploding, it normalizes the
+    nested data into flat columns using the specified prefix, making it easier to analyze
+    and manipulate. The new columns are added to the original dataframe.
+
+    Args:
+        dataframe: The input DataFrame that contains the column to explode and normalize.
+        column: The name of the column in the DataFrame that contains the list-like data to explode.
+        prefix: The prefix to add to the new column names created during the normalization process.
+
+    Returns:
+        DataFrame:
+        - A new DataFrame with the exploded rows and the normalized columns, all combined
+        with the original data in the dataframe.
+        - If the column is not found in the dataframe, the original dataframe is returned unchanged.
+    """
+    if column in dataframe:
+        exploded_dataframe = dataframe.explode(column, ignore_index=True)
+        normalized_dataframe = pd.json_normalize(
+            exploded_dataframe.pop(column)
+        ).add_prefix(prefix)
+
+        return pd.concat([exploded_dataframe, normalized_dataframe], axis=1)
+
+    return dataframe
 
 
 def __restructure_steps(steps: List[Step]) -> List[Dict[str, Any]]:
@@ -72,30 +93,34 @@ def __restructure_steps(steps: List[Step]) -> List[Dict[str, Any]]:
         List[Step]: Restructured steps - modification involves the conversion of list of inputs and outputs
         into dictionaries respectively.
     """
+    INPUTS = StepProjection.INPUTS.lower()
+    OUTPUTS = StepProjection.OUTPUTS.lower()
     restructured_steps = []
 
     for step in steps:
         step_dict = step.dict(exclude_none=True)
-        step_dict[StepProjection.INPUTS.lower()] = (
-            {item.name: item.value for item in step.inputs} if step.inputs else {}
-        )
-        step_dict[StepProjection.OUTPUTS.lower()] = (
-            {item.name: item.value for item in step.outputs} if step.outputs else {}
-        )
+        if INPUTS in step_dict:
+            step_dict[INPUTS] = (
+                {item.name: item.value for item in step.inputs} if step.inputs else {}
+            )
+        if OUTPUTS in step_dict:
+            step_dict[OUTPUTS] = (
+                {item.name: item.value for item in step.outputs} if step.outputs else {}
+            )
 
         restructured_steps.append(step_dict)
 
     return restructured_steps
 
 
-def __group_step_columns(df_columns: List[str]) -> List[str]:
+def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
     """Groups and orders dataframe columns into predefined categories to maintain a consistent structure.
 
     When normalizing steps into a dataframe, new input, output, or property fields may be added at the end,
     disrupting the expected column order. This function ensures columns are grouped properly.
 
     Args:
-        df_columns: The list of all columns from the normalized dataframe.
+        dataframe_columns: The list of all columns from the normalized dataframe.
 
     Returns:
         List[str]: A list containing grouped and ordered columns.
@@ -111,7 +136,7 @@ def __group_step_columns(df_columns: List[str]) -> List[str]:
 
     grouped_columns: Dict[str, List[str]] = {category: [] for category in CATEGORY_KEYS}
 
-    for column in df_columns:
+    for column in dataframe_columns:
         column_lower = column.lower()
         if (
             StepProjection.DATA.lower() in column_lower

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -6,7 +6,8 @@ from nisystemlink.clients.testmonitor.utilities.constants import DataFrameHeader
 
 
 def is_step_data_with_name_and_measurement(data: Dict[str, Any]) -> bool:
-    """Checks if a measurement is required by ensuring it has both 'name' and 'measurement' fields.
+    """Checks if a step data parameter is a measurement data by ensuring it 
+    has both 'name' and 'measurement' fields.
 
     Args:
         measurement: A dictionary containing measurement data.
@@ -62,7 +63,7 @@ def convert_steps_to_dataframe(
     Args:
         steps: A list of steps.
         is_measurement_data_parameter: Optional callback function that checks if a step data parameter is a
-            required measurement so that only those are included in the resultant dataframe. The method takes
+            measurement so that only those are included in the returned dataframe. The method takes
             a dictionary as input and returns a boolean value.
             The default behavior is to consider only parameters that have both 'name' and 'measurement'
             fields as measurement parameters.
@@ -324,21 +325,20 @@ def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
     GENERAL_CATEGORIES = "general"
     CATEGORY_KEYS = [
         GENERAL_CATEGORIES,
-        StepProjection.INPUTS,
-        StepProjection.OUTPUTS,
-        StepProjection.DATA,
-        StepProjection.PROPERTIES,
+        StepProjection.INPUTS.lower(),
+        StepProjection.OUTPUTS.lower(),
+        StepProjection.DATA.lower(),
+        StepProjection.PROPERTIES.lower(),
     ]
-    category_keys_lower = [category.lower() for category in CATEGORY_KEYS]
     grouped_columns: Dict[str, List[str]] = {
-        category: [] for category in category_keys_lower
+        category: [] for category in CATEGORY_KEYS
     }
     for column in dataframe_columns:
         column_lower = column.lower()
         key = next(
             (
                 category
-                for category in category_keys_lower[1:]
+                for category in CATEGORY_KEYS[1:]
                 if column_lower.startswith(category)
                 and column != StepProjection.DATA_MODEL.lower()
             ),
@@ -347,6 +347,6 @@ def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
         grouped_columns[key].append(column)
     return [
         column
-        for category_key in category_keys_lower
+        for category_key in CATEGORY_KEYS
         for column in grouped_columns[category_key]
     ]

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -41,8 +41,10 @@ def convert_results_to_dataframe(
 
 def convert_steps_to_dataframe(steps: List[Step]) -> pd.DataFrame:
     """Converts a list of steps into a normalized dataframe.
+
     Args:
         steps: A list of steps.
+
     Returns:
         DataFrame:
             - A Pandas DataFrame containing the steps data. The DataFrame would consist of all the
@@ -156,8 +158,10 @@ def __is_property_header(header: str) -> bool:
 
 def __convert_steps_to_dict(steps: List[Step]) -> List[Dict[str, Any]]:
     """Converts a list of steps to dictionaries, excluding None values.
+
     Args:
         steps: A list of steps.
+
     Returns:
         List[Dict[str, Any]]: A list of dictionaries containing step information.
     """
@@ -174,9 +178,11 @@ def __normalize_inputs_outputs(
     step: Step,
 ) -> None:
     """Normalizes the input and output fields by converting them into dictionaries.
+
     Args:
         step_dict: A dictionary with step information.
         step: A Step object containing inputs and outputs.
+
     Returns:
         None: The function modifies step_dict in place.
     """
@@ -200,10 +206,12 @@ def __explode_and_normalize(
     transforming each list element into a separate row. After exploding, it normalizes the
     nested data into flat columns using the specified prefix, making it easier to analyze
     and manipulate. The new columns are added to the original dataframe.
+
     Args:
         dataframe: The input DataFrame that contains the column to explode and normalize.
         column: The name of the column in the DataFrame that contains the list-like data to explode.
         prefix: The prefix to add to the new column names created during the normalization process.
+
     Returns:
         DataFrame:
         - A new DataFrame with the exploded rows and the normalized columns, all combined
@@ -223,8 +231,10 @@ def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
     """Groups and orders dataframe columns into predefined categories to maintain a consistent structure.
     When normalizing steps into a dataframe, new input, output, or property fields may be added at the end,
     disrupting the expected column order. This function ensures columns are grouped properly.
+
     Args:
         dataframe_columns: The list of all columns from the normalized dataframe.
+
     Returns:
         List[str]: A list containing grouped and ordered columns.
     """

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -221,13 +221,14 @@ def __filter_invalid_measurements(
     """Gets data parameters from the step dictionary and filters it based on the callback function.
 
     Args:
+        step_dict: A dictionary with step information.
         step: A Step object containing data parameters.
         is_valid_measurement: Optional callback function to check if a measurement is valid. The method takes
             a dictionary as input and returns a boolean value. The default behavior is to consider only parameters
             that have both 'name' and 'measurement' fields with values as valid measurements.
 
     Returns:
-        None: The function modifies step parameters in place with filtered data parameters.
+        None: The function modifies step dictionary in place with filtered data parameters.
     """
     if step.data and step.data.parameters and is_valid_measurement is not None:
         valid_measurement_parameters = []

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -169,6 +169,7 @@ def __convert_steps_to_dict(steps: List[Step]) -> List[Dict[str, Any]]:
     for step in steps:
         single_step_dict = step.dict(exclude_none=True)
         __normalize_inputs_outputs(single_step_dict, step)
+        __normalize_step_status(single_step_dict)
         steps_dict.append(single_step_dict)
     return steps_dict
 
@@ -196,6 +197,14 @@ def __normalize_inputs_outputs(
         step_dict[STEP_OUTPUTS] = (
             {item.name: item.value for item in step.outputs} if step.outputs else {}
         )
+
+
+def __normalize_step_status(step_dict: Dict[str, Any]) -> None:
+    step_status = step_dict.get("status", {})
+    if step_status.get("status_type") == "CUSTOM":
+        step_dict["status"] = step_status["status_name"]
+    else:
+        step_dict["status"] = step_status["status_type"].value
 
 
 def __explode_and_normalize(

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -253,7 +253,7 @@ def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
             (
                 category
                 for category in CATEGORY_KEYS
-                if column_lower.startswith(f"{category.lower()}.")
+                if column_lower.startswith(category.lower())
                 and column != StepProjection.DATA_MODEL.lower()
             ),
             GENERAL_CATEGORIES,

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -70,7 +70,7 @@ def convert_steps_to_dataframe(
             valid measurement so that only those are included in the returned dataframe. The method takes
             a measurement as input and returns a boolean value.
             The default behavior is to consider only measurement data that have both 'name' and 'measurement'
-            fields with values as valid measurement.
+            fields with values as valid measurements.
             If none of the measurements have the required fields, the data.parameters will not
             appear in the dataframe.
             If the callback function is set to None, all step data parameters will be included in the dataframe.
@@ -221,7 +221,7 @@ def __filter_invalid_measurements(
         step: A Step object containing data parameters.
         is_valid_measurement: Optional callback function to check if a measurement is valid. The method takes
             a dictionary as input and returns a boolean value. The default behavior is to consider only parameters
-            that have both 'name' and 'measurement' fields with values as valid measurement.
+            that have both 'name' and 'measurement' fields with values as valid measurements.
 
     Returns:
         None: The function modifies step parameters in place with filtered data parameters.

--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -320,7 +320,7 @@ def __group_step_columns(dataframe_columns: List[str]) -> List[str]:
         key = next(
             (
                 category
-                for category in CATEGORY_KEYS
+                for category in CATEGORY_KEYS[1:]
                 if column_lower.startswith(category.lower())
                 and column != StepProjection.DATA_MODEL.lower()
             ),

--- a/nisystemlink/clients/testmonitor/utilities/constants.py
+++ b/nisystemlink/clients/testmonitor/utilities/constants.py
@@ -2,3 +2,10 @@ class DataFrameHeaders:
     STATUS_TYPE_SUMMARY_HEADER_PREFIX = "status_type_summary."
 
     PROPERTY_COLUMN_HEADER_PREFIX = "properties."
+
+    CATEGORY_COLUMN_HEADERS = [
+        "general",
+        "outputs",
+        "data",
+        "properties",
+    ]

--- a/tests/testmonitor/__init__.py
+++ b/tests/testmonitor/__init__.py
@@ -1,0 +1,1 @@
+# flake8: noqa

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -352,25 +352,23 @@ class TestTestmonitorDataframeUtilities:
             steps_dataframe, expected_steps_dataframe, check_dtype=True
         )
 
-    def test__convert_steps_to_dataframe_with_is_callback__returns_dataframe_with_valid_measurement(
+    def test__convert_steps_to_dataframe_with_callback__returns_dataframe_with_valid_measurement(
         self, mock_steps_data: List[Step]
     ):
         """Test if the function returns a dataframe of steps with valid measurement."""
 
         def is_measurement_data_parameter(step_dict: Dict[str, Any]) -> bool:
-            return all(key in step_dict for key in desired_measurement_keys)
+            return set(required_measurement_fields).issubset(set(step_dict.keys()))
 
-        desired_measurement_keys = ["name", "temperature"]
+        required_measurement_fields = ["name", "temperature"]
         expected_steps_dataframe = self.__get_expected_steps_dataframe(
-            mock_steps_data, desired_measurement_keys
+            mock_steps_data, required_measurement_fields
         )
 
         steps_dataframe = convert_steps_to_dataframe(
             mock_steps_data, is_measurement_data_parameter
         )
 
-        # import pdb
-        # pdb.set_trace()
         assert not steps_dataframe.empty
         assert (
             steps_dataframe.columns.to_list()
@@ -444,7 +442,7 @@ class TestTestmonitorDataframeUtilities:
     def __get_expected_steps_dataframe(
         self,
         mock_steps_data: List[Step],
-        measurement_keys: Optional[List[str]] = ["name", "measurement"],
+        measurement_fields: Optional[List[str]] = ["name", "measurement"],
     ) -> pd.DataFrame:
         restructured_mock_steps = []
         for step in mock_steps_data:
@@ -499,7 +497,7 @@ class TestTestmonitorDataframeUtilities:
                     if all(
                         hasattr(measurement, key)
                         and getattr(measurement, key) is not None
-                        for key in (measurement_keys or [])
+                        for key in (measurement_fields or [])
                     )
                 ]
             else:

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -251,8 +251,6 @@ class TestTestMonitorDataframeUtilities:
         """Test case when the input steps data is empty."""
         steps_dataframe = convert_steps_to_dataframe(empty_steps_data)
 
-        print(steps_dataframe)
-
         assert steps_dataframe.empty
 
     def test__convert_steps_to_dataframe__with_missing_fields(
@@ -263,6 +261,7 @@ class TestTestMonitorDataframeUtilities:
         for step in steps:
             step.path_ids = None
             step.data = None
+            step.inputs = None
 
         steps_dataframe = convert_steps_to_dataframe(steps)
         expected_steps_dataframe = expected_steps_dataframe.drop(
@@ -276,6 +275,10 @@ class TestTestMonitorDataframeUtilities:
                 "data.parameters.measurement",
                 "data.parameters.comparisonType",
                 "data.text",
+                "inputs.Input11",
+                "inputs.Input12",
+                "inputs.Input21",
+                "inputs.Input22",
             ]
         )
         expected_steps_dataframe = expected_steps_dataframe.drop_duplicates(

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -289,25 +289,25 @@ class TestTestmonitorDataframeUtilities:
         expected_data_parameters = [
             [
                 {
-                    "data.parameters.name": "parameter_11",
-                    "data.parameters.status": "Passed",
-                    "data.parameters.measurement": "11.0",
-                    "data.parameters.lowLimit": "6.0",
-                    "data.parameters.highLimit": "21.0",
-                    "data.parameters.units": "A",
-                    "data.parameters.comparisonType": "GTLT",
+                    "data.measurement.name": "parameter_11",
+                    "data.measurement.status": "Passed",
+                    "data.measurement.measurement": "11.0",
+                    "data.measurement.lowLimit": "6.0",
+                    "data.measurement.highLimit": "21.0",
+                    "data.measurement.units": "A",
+                    "data.measurement.comparisonType": "GTLT",
                 }
             ],
             [
                 {
-                    "data.parameters.name": "parameter_21",
-                    "data.parameters.status": "Passed",
-                    "data.parameters.measurement": "11.0",
-                    "data.parameters.lowLimit": "6.0",
-                    "data.parameters.highLimit": "21.0",
-                    "data.parameters.units": "A",
-                    "data.parameters.comparisonType": "GTLT",
-                    "data.parameters.additionalData": "additional_data_value",
+                    "data.measurement.name": "parameter_21",
+                    "data.measurement.status": "Passed",
+                    "data.measurement.measurement": "11.0",
+                    "data.measurement.lowLimit": "6.0",
+                    "data.measurement.highLimit": "21.0",
+                    "data.measurement.units": "A",
+                    "data.measurement.comparisonType": "GTLT",
+                    "data.measurement.additionalData": "additional_data_value",
                 }
             ],
         ]
@@ -388,14 +388,14 @@ class TestTestmonitorDataframeUtilities:
             [{}],
             [
                 {
-                    "data.parameters.name": "parameter_21",
-                    "data.parameters.status": "Passed",
-                    "data.parameters.measurement": "11.0",
-                    "data.parameters.lowLimit": "6.0",
-                    "data.parameters.highLimit": "21.0",
-                    "data.parameters.units": "A",
-                    "data.parameters.comparisonType": "GTLT",
-                    "data.parameters.additionalData": "additional_data_value",
+                    "data.measurement.name": "parameter_21",
+                    "data.measurement.status": "Passed",
+                    "data.measurement.measurement": "11.0",
+                    "data.measurement.lowLimit": "6.0",
+                    "data.measurement.highLimit": "21.0",
+                    "data.measurement.units": "A",
+                    "data.measurement.comparisonType": "GTLT",
+                    "data.measurement.additionalData": "additional_data_value",
                 }
             ],
         ]
@@ -458,7 +458,7 @@ class TestTestmonitorDataframeUtilities:
             steps_dataframe, expected_steps_dataframe, check_dtype=True
         )
 
-    def test__convert_steps_to_dataframe_with_None_callback__returns_step_with_all_data_parameters(
+    def test__convert_steps_to_dataframe_with_none_callback__returns_step_with_all_data_parameters(
         self, mock_steps_data: List[Step]
     ):
         """Test normal case with valid step data."""
@@ -501,6 +501,7 @@ class TestTestmonitorDataframeUtilities:
         expected_steps_dataframe = self.__get_expected_steps_dataframe(
             mock_steps_data,
             expected_data_parameters=expected_data_parameters,
+            data_parameters_prefix="data.parameters",
         )
 
         steps_dataframe = convert_steps_to_dataframe(mock_steps_data, None)
@@ -581,6 +582,7 @@ class TestTestmonitorDataframeUtilities:
         mock_steps_data: List[Step],
         expected_data_parameters=None,
         expected_column_order=None,
+        data_parameters_prefix="data.measurement",
     ) -> pd.DataFrame:
         steps_with_measurement_per_row = []
         index = 0
@@ -638,7 +640,9 @@ class TestTestmonitorDataframeUtilities:
         steps_dataframe = pd.DataFrame(steps_with_measurement_per_row)
 
         dataframe_columns = [
-            col for col in steps_dataframe.columns if col.startswith("data.parameters.")
+            col
+            for col in steps_dataframe.columns
+            if col.startswith(data_parameters_prefix)
         ]
         default_column_order = [
             "name",

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -124,9 +124,7 @@ def mock_steps_data() -> List[Step]:
                     measurement="11.0",
                     comparisonType="GTLT",
                 ),
-                Measurement(
-                    nitmParameterType="additional_results", additionalProp="myValue"
-                ),
+                Measurement(additionalProp="myValue"),
             ],
         ),
         has_children=False,
@@ -171,7 +169,7 @@ def mock_steps_data() -> List[Step]:
                     highLimit="21.0",
                     measurement="11.0",
                     comparisonType="GTLT",
-                    additional_data="additional_data_value",
+                    additionalData="additional_data_value",
                 ),
                 Measurement(
                     name="parameter_22",
@@ -309,7 +307,7 @@ class TestTestmonitorDataframeUtilities:
                     "data.parameters.highLimit": "21.0",
                     "data.parameters.units": "A",
                     "data.parameters.comparisonType": "GTLT",
-                    "data.parameters.additional_data": "additional_data_value",
+                    "data.parameters.additionalData": "additional_data_value",
                 }
             ],
         ]
@@ -383,7 +381,7 @@ class TestTestmonitorDataframeUtilities:
 
         def is_measurement_data_parameter(measurement: Measurement) -> bool:
             return measurement.name is not None and hasattr(
-                measurement, "additional_data"
+                measurement, "additionalData"
             )
 
         expected_data_parameters = [
@@ -397,7 +395,7 @@ class TestTestmonitorDataframeUtilities:
                     "data.parameters.highLimit": "21.0",
                     "data.parameters.units": "A",
                     "data.parameters.comparisonType": "GTLT",
-                    "data.parameters.additional_data": "additional_data_value",
+                    "data.parameters.additionalData": "additional_data_value",
                 }
             ],
         ]
@@ -477,7 +475,6 @@ class TestTestmonitorDataframeUtilities:
                 },
                 {
                     "data.parameters.additionalProp": "myValue",
-                    "data.parameters.nitmParameterType": "additional_results",
                 },
             ],
             [
@@ -489,7 +486,7 @@ class TestTestmonitorDataframeUtilities:
                     "data.parameters.highLimit": "21.0",
                     "data.parameters.units": "A",
                     "data.parameters.comparisonType": "GTLT",
-                    "data.parameters.additional_data": "additional_data_value",
+                    "data.parameters.additionalData": "additional_data_value",
                 },
                 {
                     "data.parameters.name": "parameter_22",
@@ -502,7 +499,8 @@ class TestTestmonitorDataframeUtilities:
             ],
         ]
         expected_steps_dataframe = self.__get_expected_steps_dataframe(
-            mock_steps_data, expected_data_parameters=expected_data_parameters
+            mock_steps_data,
+            expected_data_parameters=expected_data_parameters,
         )
 
         steps_dataframe = convert_steps_to_dataframe(mock_steps_data, None)

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -30,6 +30,7 @@ def mock_steps_data() -> List[Step]:
         started_at=datetime(2023, 3, 27, 18, 39, 49, tzinfo=timezone.utc),
         updated_at=datetime(2024, 2, 2, 14, 22, 4, 625155, tzinfo=timezone.utc),
         inputs=[
+            NamedValue(name="Input00", value="input_value_00"),
             NamedValue(name="Input11", value="input_value_11"),
             NamedValue(name="Input12", value="input_value_12"),
         ],
@@ -70,6 +71,7 @@ def mock_steps_data() -> List[Step]:
         started_at=datetime(2023, 3, 27, 18, 39, 49, tzinfo=timezone.utc),
         updated_at=datetime(2024, 2, 2, 14, 22, 4, 625255, tzinfo=timezone.utc),
         inputs=[
+            NamedValue(name="Input00", value="input_value_00"),
             NamedValue(name="Input21", value="input_value_21"),
             NamedValue(name="Input22", value="input_value_22"),
         ],
@@ -183,6 +185,7 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> DataFrame:
         "keywords",
         "status.status_type",
         "status.status_name",
+        "inputs.Input00",
         "inputs.Input11",
         "inputs.Input12",
         "inputs.Input21",
@@ -205,7 +208,7 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> DataFrame:
         "properties.property22",
     ]
 
-    return expected_dataframe.reindex(columns=expected_column_order)
+    return expected_dataframe.reindex(columns=expected_column_order, copy=False)
 
 
 @pytest.fixture
@@ -266,6 +269,7 @@ class TestTestMonitorDataframeUtilities:
                 "data.parameters.measurement",
                 "data.parameters.comparisonType",
                 "data.text",
+                "inputs.Input00",
                 "inputs.Input11",
                 "inputs.Input12",
                 "inputs.Input21",

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -468,7 +468,7 @@ class TestTestmonitorDataframeUtilities:
                 "has_children": step.has_children,
                 "workspace": step.workspace,
                 "keywords": step.keywords,
-                "data.text": step.data.text,
+                "data.text": step.data.text if step.data else None,
             }
 
             restructured_step.update(
@@ -499,7 +499,7 @@ class TestTestmonitorDataframeUtilities:
                     if all(
                         hasattr(measurement, key)
                         and getattr(measurement, key) is not None
-                        for key in measurement_keys
+                        for key in (measurement_keys or [])
                     )
                 ]
             else:

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -442,7 +442,9 @@ class TestTestmonitorDataframeUtilities:
         return results_df
 
     def __get_expected_steps_dataframe(
-        self, mock_steps_data: List[Step], measurement_keys: Optional[List[str]] = ["name", "measurement"]
+        self,
+        mock_steps_data: List[Step],
+        measurement_keys: Optional[List[str]] = ["name", "measurement"],
     ) -> pd.DataFrame:
         restructured_mock_steps = []
         for step in mock_steps_data:

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -1,0 +1,292 @@
+from datetime import datetime, timezone
+from typing import List
+
+import pandas as pd
+import pytest
+from nisystemlink.clients.testmonitor.models import (
+    NamedValue,
+    Status,
+    StatusType,
+    Step,
+    StepData,
+)
+from nisystemlink.clients.testmonitor.utilities import convert_steps_to_dataframe
+from pandas import DataFrame
+
+
+@pytest.fixture
+def mock_steps_data() -> List[Step]:
+    """Fixture to return a mock step data."""
+    step1 = Step(
+        name="MockStep1",
+        step_type="StepType",
+        step_id="5ffb2bf6771fa11e877838dd1",
+        parent_id="5ffb2bf6771fa11e877838dd2",
+        result_id="5ffb2bf6771fa11e877838dd3",
+        path="Path",
+        path_ids=["path_id_11", "path_id_12"],
+        status=Status(status_type=StatusType.DONE, status_name="Done"),
+        total_time_in_seconds=5,
+        started_at=datetime(2023, 3, 27, 18, 39, 49, tzinfo=timezone.utc),
+        updated_at=datetime(2024, 2, 2, 14, 22, 4, 625155, tzinfo=timezone.utc),
+        inputs=[
+            NamedValue(name="Input11", value="input_value_11"),
+            NamedValue(name="Input12", value="input_value_12"),
+        ],
+        outputs=[
+            NamedValue(name="Output11", value="output_value_11"),
+            NamedValue(name="Output12", value="output_value_12"),
+        ],
+        data_model="STDF",
+        data=StepData(
+            text="data1",
+            parameters=[
+                {
+                    "name": "parameter_11",
+                    "units": "A",
+                    "status": "Failed",
+                    "lowLimit": "6.0",
+                    "highLimit": "21.0",
+                    "measurement": "11.0",
+                    "comparisonType": "GTLT",
+                },
+                {
+                    "name": "parameter_12",
+                    "units": "B",
+                    "status": "Passed",
+                    "lowLimit": "7.0",
+                    "highLimit": "22.0",
+                    "measurement": "12.0",
+                    "comparisonType": "GTLT",
+                },
+            ],
+        ),
+        has_children=False,
+        workspace="846e294a-a007-47ac-9fc2-fac07eab240f",
+        keywords=["keyword11", "keyword12"],
+        properties={"property11": "property11_value", "property12": "property12_value"},
+    )
+    step2 = Step(
+        name="MockStep2",
+        step_type="StepType",
+        step_id="5ffb2bf6771fa11e877838dd6",
+        parent_id="5ffb2bf6771fa11e877838dd7",
+        result_id="5ffb2bf6771fa11e877838dd8",
+        path="Path",
+        path_ids=["path_id_21", "path_id_22"],
+        status=Status(status_type=StatusType.DONE, status_name="Done"),
+        total_time_in_seconds=5,
+        started_at=datetime(2023, 3, 27, 18, 39, 49, tzinfo=timezone.utc),
+        updated_at=datetime(2024, 2, 2, 14, 22, 4, 625255, tzinfo=timezone.utc),
+        inputs=[
+            NamedValue(name="Input21", value="input_value_21"),
+            NamedValue(name="Input22", value="input_value_22"),
+        ],
+        outputs=[
+            NamedValue(name="Output21", value="output_value_21"),
+            NamedValue(name="Output22", value="output_value_22"),
+        ],
+        data_model="STDF",
+        data=StepData(
+            text="data2",
+            parameters=[
+                {
+                    "name": "parameter_21",
+                    "units": "A",
+                    "status": "Passed",
+                    "lowLimit": "6.0",
+                    "highLimit": "21.0",
+                    "measurement": "11.0",
+                    "comparisonType": "GTLT",
+                },
+                {
+                    "name": "parameter_22",
+                    "units": "C",
+                    "status": "Passed",
+                    "lowLimit": "7.0",
+                    "highLimit": "22.0",
+                    "measurement": "12.0",
+                    "comparisonType": "GTLT",
+                },
+            ],
+        ),
+        has_children=True,
+        workspace="846e294a-a007-47ac-9fc2-fac07eab240z",
+        keywords=["keyword21", "keyword22"],
+        properties={"property21": "property21_value", "property22": "property22_value"},
+    )
+
+    return [step1, step2]
+
+
+@pytest.fixture
+def expected_steps_dataframe(mock_steps_data: List[Step]) -> DataFrame:
+    """Fixture to return the expected DataFrame based on the mock step data."""
+    restructured_mock_steps = []
+
+    for step in mock_steps_data:
+        properties = (
+            {f"properties.{key}": value for key, value in step.properties.items()}
+            if step.properties
+            else {}
+        )
+        inputs = (
+            {f"inputs.{item.name}": item.value for item in step.inputs}
+            if step.inputs
+            else {}
+        )
+        outputs = (
+            {f"outputs.{item.name}": item.value for item in step.outputs}
+            if step.outputs
+            else {}
+        )
+
+        if not (step.data and step.data.parameters):
+            continue
+
+        for parametric_data in step.data.parameters:
+            parameter_data = {
+                f"data.parameters.{key}": value
+                for key, value in parametric_data.dict().items()
+            }
+            restructured_step = {
+                "name": step.name,
+                "step_type": step.step_type,
+                "step_id": step.step_id,
+                "parent_id": step.parent_id,
+                "result_id": step.result_id,
+                "path": step.path,
+                "path_ids": step.path_ids,
+                "total_time_in_seconds": step.total_time_in_seconds,
+                "started_at": step.started_at,
+                "updated_at": step.updated_at,
+                "data_model": step.data_model,
+                "has_children": step.has_children,
+                "workspace": step.workspace,
+                "keywords": step.keywords,
+                "status.status_type": step.status.status_type if step.status else None,
+                "status.status_name": step.status.status_name if step.status else None,
+                **inputs,
+                **outputs,
+                "data.text": step.data.text,
+                **parameter_data,
+                **properties,
+            }
+            restructured_mock_steps.append(restructured_step)
+
+    expected_dataframe = DataFrame(restructured_mock_steps)
+    expected_column_order = [
+        "name",
+        "step_type",
+        "step_id",
+        "parent_id",
+        "result_id",
+        "path",
+        "path_ids",
+        "total_time_in_seconds",
+        "started_at",
+        "updated_at",
+        "data_model",
+        "has_children",
+        "workspace",
+        "keywords",
+        "status.status_type",
+        "status.status_name",
+        "inputs.Input11",
+        "inputs.Input12",
+        "inputs.Input21",
+        "inputs.Input22",
+        "outputs.Output11",
+        "outputs.Output12",
+        "outputs.Output21",
+        "outputs.Output22",
+        "data.text",
+        "data.parameters.name",
+        "data.parameters.status",
+        "data.parameters.measurement",
+        "data.parameters.lowLimit",
+        "data.parameters.highLimit",
+        "data.parameters.units",
+        "data.parameters.comparisonType",
+        "properties.property11",
+        "properties.property12",
+        "properties.property21",
+        "properties.property22",
+    ]
+
+    return expected_dataframe.reindex(columns=expected_column_order)
+
+
+@pytest.fixture
+def empty_steps_data() -> List:
+    """Fixture to return an empty list of steps."""
+    return []
+
+
+@pytest.mark.enterprise
+@pytest.mark.unit
+class TestTestMonitorDataframeUtilities:
+    def test__convert_steps_to_dataframe__with_complete_data(
+        self, mock_steps_data: List[Step], expected_steps_dataframe: DataFrame
+    ):
+        """Test normal case with valid step data."""
+        steps_dataframe = convert_steps_to_dataframe(mock_steps_data)
+
+        assert not steps_dataframe.empty
+        assert (
+            steps_dataframe.columns.to_list()
+            == expected_steps_dataframe.columns.to_list()
+        )
+        assert steps_dataframe["updated_at"].dtype == "datetime64[ns, UTC]"
+        assert steps_dataframe["started_at"].dtype == "datetime64[ns, UTC]"
+        assert steps_dataframe["path_ids"].dtype == "object"
+        assert isinstance(steps_dataframe["path_ids"].iloc[0], List)
+        assert steps_dataframe["keywords"].dtype == "object"
+        assert isinstance(steps_dataframe["keywords"].iloc[0], List)
+        pd.testing.assert_frame_equal(
+            steps_dataframe, expected_steps_dataframe, check_dtype=True
+        )
+
+    def test__convert_steps_to_dataframe__with_empty_data(self, empty_steps_data: List):
+        """Test case when the input steps data is empty."""
+        steps_dataframe = convert_steps_to_dataframe(empty_steps_data)
+
+        print(steps_dataframe)
+
+        assert steps_dataframe.empty
+
+    def test__convert_steps_to_dataframe__with_missing_fields(
+        self, mock_steps_data: List[Step], expected_steps_dataframe: DataFrame
+    ):
+        """Test case when some fields in step data are missing."""
+        steps = mock_steps_data
+        for step in steps:
+            step.path_ids = None
+            step.data = None
+
+        steps_dataframe = convert_steps_to_dataframe(steps)
+        expected_steps_dataframe = expected_steps_dataframe.drop(
+            columns=[
+                "path_ids",
+                "data.parameters.name",
+                "data.parameters.units",
+                "data.parameters.status",
+                "data.parameters.lowLimit",
+                "data.parameters.highLimit",
+                "data.parameters.measurement",
+                "data.parameters.comparisonType",
+                "data.text",
+            ]
+        )
+        expected_steps_dataframe = expected_steps_dataframe.drop_duplicates(
+            subset=["step_id", "result_id"], ignore_index=True
+        )
+
+        assert not steps_dataframe.empty
+        assert (
+            steps_dataframe.columns.to_list()
+            == expected_steps_dataframe.columns.to_list()
+        )
+        pd.testing.assert_frame_equal(
+            steps_dataframe, expected_steps_dataframe, check_dtype=True
+        )

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -174,7 +174,6 @@ def mock_steps_data() -> List[Step]:
                     "status": "Passed",
                     "lowLimit": "7.0",
                     "highLimit": "22.0",
-                    "measurement": "12.0",
                     "comparisonType": "GTLT",
                 },
             ],
@@ -210,38 +209,42 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
         if not (step.data and step.data.parameters):
             continue
         for parametric_data in step.data.parameters:
-            parameter_data = {
-                f"data.parameters.{key}": value
-                for key, value in parametric_data.dict().items()
-            }
+            if (
+                "name" in parametric_data.dict()
+                and "measurement" in parametric_data.dict()
+            ):
+                parameter_data = {
+                    f"data.parameters.{key}": value
+                    for key, value in parametric_data.dict().items()
+                }
 
-            restructured_step = {
-                "name": step.name,
-                "step_type": step.step_type,
-                "step_id": step.step_id,
-                "parent_id": step.parent_id,
-                "result_id": step.result_id,
-                "path": step.path,
-                "path_ids": step.path_ids,
-                "status": (
-                    step.status.status_type.value
-                    if step.status and step.status.status_type != "CUSTOM"
-                    else step.status.status_name if step.status else None
-                ),
-                "total_time_in_seconds": step.total_time_in_seconds,
-                "started_at": step.started_at,
-                "updated_at": step.updated_at,
-                "data_model": step.data_model,
-                "has_children": step.has_children,
-                "workspace": step.workspace,
-                "keywords": step.keywords,
-                **inputs,
-                **outputs,
-                "data.text": step.data.text,
-                **parameter_data,
-                **properties,
-            }
-            restructured_mock_steps.append(restructured_step)
+                restructured_step = {
+                    "name": step.name,
+                    "step_type": step.step_type,
+                    "step_id": step.step_id,
+                    "parent_id": step.parent_id,
+                    "result_id": step.result_id,
+                    "path": step.path,
+                    "path_ids": step.path_ids,
+                    "status": (
+                        step.status.status_type.value
+                        if step.status and step.status.status_type != "CUSTOM"
+                        else step.status.status_name if step.status else None
+                    ),
+                    "total_time_in_seconds": step.total_time_in_seconds,
+                    "started_at": step.started_at,
+                    "updated_at": step.updated_at,
+                    "data_model": step.data_model,
+                    "has_children": step.has_children,
+                    "workspace": step.workspace,
+                    "keywords": step.keywords,
+                    **inputs,
+                    **outputs,
+                    "data.text": step.data.text,
+                    **parameter_data,
+                    **properties,
+                }
+                restructured_mock_steps.append(restructured_step)
     expected_dataframe = pd.DataFrame(restructured_mock_steps)
     expected_column_order = [
         "name",
@@ -291,6 +294,7 @@ def empty_steps_data() -> List:
 
 
 @pytest.mark.enterprise
+@pytest.mark.unit
 class TestTestmonitorDataframeUtilities:
     def test__convert_results_with_all_fields_to_dataframe__returns_whole_results_dataframe(
         self, results

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -138,7 +138,7 @@ def mock_steps_data() -> List[Step]:
         result_id="5ffb2bf6771fa11e877838dd8",
         path="Path",
         path_ids=["path_id_21", "path_id_22"],
-        status=Status(status_type=StatusType.DONE, status_name="Done"),
+        status=Status(status_type=StatusType.CUSTOM, status_name="newstatus"),
         total_time_in_seconds=5,
         started_at=datetime.datetime(
             2023, 3, 27, 18, 39, 49, tzinfo=datetime.timezone.utc
@@ -214,6 +214,7 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
                 f"data.parameters.{key}": value
                 for key, value in parametric_data.dict().items()
             }
+
             restructured_step = {
                 "name": step.name,
                 "step_type": step.step_type,
@@ -222,6 +223,11 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
                 "result_id": step.result_id,
                 "path": step.path,
                 "path_ids": step.path_ids,
+                "status": (
+                    step.status.status_type.value
+                    if step.status and step.status.status_type != "CUSTOM"
+                    else step.status.status_name if step.status else None
+                ),
                 "total_time_in_seconds": step.total_time_in_seconds,
                 "started_at": step.started_at,
                 "updated_at": step.updated_at,
@@ -229,8 +235,6 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
                 "has_children": step.has_children,
                 "workspace": step.workspace,
                 "keywords": step.keywords,
-                "status.status_type": step.status.status_type if step.status else None,
-                "status.status_name": step.status.status_name if step.status else None,
                 **inputs,
                 **outputs,
                 "data.text": step.data.text,
@@ -247,6 +251,7 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
         "result_id",
         "path",
         "path_ids",
+        "status",
         "total_time_in_seconds",
         "started_at",
         "updated_at",
@@ -254,8 +259,6 @@ def expected_steps_dataframe(mock_steps_data: List[Step]) -> pd.DataFrame:
         "has_children",
         "workspace",
         "keywords",
-        "status.status_type",
-        "status.status_name",
         "inputs.Input00",
         "inputs.Input11",
         "inputs.Input12",

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -42,23 +42,14 @@ def mock_steps_data() -> List[Step]:
             text="data1",
             parameters=[
                 {
-                    "name": "parameter_11",
+                    "name": "parameter_21",
                     "units": "A",
-                    "status": "Failed",
+                    "status": "Passed",
                     "lowLimit": "6.0",
                     "highLimit": "21.0",
                     "measurement": "11.0",
                     "comparisonType": "GTLT",
-                },
-                {
-                    "name": "parameter_12",
-                    "units": "B",
-                    "status": "Passed",
-                    "lowLimit": "7.0",
-                    "highLimit": "22.0",
-                    "measurement": "12.0",
-                    "comparisonType": "GTLT",
-                },
+                }
             ],
         ),
         has_children=False,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds functionality to return a normalized data frame, given a list of steps as input.
- Before the process of json normalization, inputs and outputs are restructured. From an array of names and values, they are converted into a dictionary with the name as the key, mapped to the value.
- Grouping of fields are done. This is much needed because, during normalization and the data frame conversion process, if there are new fields (especially fields which are nested) found in the successive steps, then there could be inconsistency in the ordering of the columns. (Also documented in the function's doc string)

### Why should this Pull Request be merged?

This utility can be useful to get the steps data in the form of a Data frame which can be useful for further processing.

### What testing has been done?

Unit tests are added
