### PR TITLE
fix: Delete product created during result client test fixture

### DIFF
--- a/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
+++ b/nisystemlink/clients/testmonitor/utilities/_dataframe_utilities.py
@@ -12,9 +12,8 @@ def convert_results_to_dataframe(
 
     Args:
         results: The list of results to be included in the dataframe.
-        set_id_as_index: If true, result id will be set as index for the dataframe.
+        set_id_as_index: If true (default value), result id will be set as index for the dataframe.
                          If false, index will not be set.
-                         Default value is false.
 
     Returns:
         A Pandas DataFrame with the each result fields having a separate column.

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -5,7 +5,10 @@ import pytest
 from nisystemlink.clients.core._api_exception import ApiException
 from nisystemlink.clients.core._http_configuration import HttpConfiguration
 from nisystemlink.clients.product._product_client import ProductClient
-from nisystemlink.clients.product.models._query_products_request import ProductProjection, QueryProductsRequest
+from nisystemlink.clients.product.models._query_products_request import (
+    ProductProjection,
+    QueryProductsRequest,
+)
 from nisystemlink.clients.testmonitor import TestMonitorClient
 from nisystemlink.clients.testmonitor.models import (
     CreateResultRequest,
@@ -76,9 +79,16 @@ def create_results(client: TestMonitorClient, product_client: ProductClient):
 
     client.delete_results(ids=[str(result.id) for result in created_results])
 
-    product = product_client.query_products_paged(QueryProductsRequest(
-        filter=f'partNumber="{part_number_of_created_product}"', projection=[ProductProjection.ID], take=1))
-    product_client.delete_product(product.products[0].id)
+    product = product_client.query_products_paged(
+        QueryProductsRequest(
+            filter=f'partNumber="{part_number_of_created_product}"',
+            projection=[ProductProjection.ID],
+            take=1,
+        )
+    )
+
+    if product.products[0].id:
+        product_client.delete_product(id=product.products[0].id)
 
 
 @pytest.fixture

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -75,20 +75,20 @@ def create_results(client: TestMonitorClient, product_client: ProductClient):
         if response.results:
             created_results = created_results + response.results
 
-    part_numbers_of_created_products = list(
-        set(result.part_number for result in created_results)
+    part_numbers_of_created_products = set(
+        result.part_number for result in created_results
     )
 
     client.delete_results(ids=[str(result.id) for result in created_results])
 
-    filter_string = " or ".join(
+    product_filter_string = " or ".join(
         [
             f'partNumber="{part_number}"'
             for part_number in part_numbers_of_created_products
         ]
     )
     created_product_ids = product_client.query_product_values(
-        QueryProductValuesRequest(filter=filter_string, field=ProductField.ID)
+        QueryProductValuesRequest(filter=product_filter_string, field=ProductField.ID)
     )
 
     product_client.delete_products(ids=created_product_ids)

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -33,6 +33,7 @@ from nisystemlink.clients.testmonitor.models._query_results_request import (
     QueryResultsRequest,
     QueryResultValuesRequest,
     ResultField,
+    ResultProjection,
 )
 from nisystemlink.clients.testmonitor.models._step_data import Measurement, StepData
 
@@ -128,12 +129,12 @@ class TestTestMonitor:
         assert len(response.dict()) != 0
 
     def test__create_single_result__one_result_created_with_right_field_values(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
-        part_number = unique_identifier
+        part_number = "Python Client Testing"
         keywords = ["testing"]
         properties = {"test_property": "yes"}
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         host_name = "Test Host"
         system_id = "Test System"
@@ -166,7 +167,7 @@ class TestTestMonitor:
     def test__create_multiple_results__multiple_creates_succeed(
         self, client: TestMonitorClient, create_results
     ):
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         results = [
             CreateResultRequest(
@@ -183,13 +184,13 @@ class TestTestMonitor:
         assert len(response.results) == 2
 
     def test__create_single_result_and_get_results__at_least_one_result_exists(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
+                part_number="Python Client Testing",
                 program_name=program_name,
                 status=status,
                 properties={"test": None},
@@ -203,16 +204,20 @@ class TestTestMonitor:
         assert len(get_response.results) >= 1
 
     def test__create_multiple_results_and_get_results_with_take__only_take_returned(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status
+                part_number="Python Client Testing",
+                program_name=program_name,
+                status=status,
             ),
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status
+                part_number="Python Client Testing",
+                program_name=program_name,
+                status=status,
             ),
         ]
         create_results(results)
@@ -223,16 +228,20 @@ class TestTestMonitor:
         assert len(get_response.results) == 1
 
     def test__create_multiple_results_and_get_results_with_count_at_least_one_count(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status
+                part_number="Python Client Testing",
+                program_name=program_name,
+                status=status,
             ),
             CreateResultRequest(
-                part_number=unique_identifier, program_name=program_name, status=status
+                part_number="Python Client Testing",
+                program_name=program_name,
+                status=status,
             ),
         ]
         create_results(results)
@@ -243,10 +252,10 @@ class TestTestMonitor:
         assert get_response.total_count is not None and get_response.total_count >= 2
 
     def test__get_result_by_id__result_matches_expected(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
-        part_number = unique_identifier
-        program_name = "Test Program"
+        part_number = "Python Client Testing"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         results = [
             CreateResultRequest(
@@ -264,63 +273,76 @@ class TestTestMonitor:
         assert result.program_name == program_name
         assert result.status == status
 
-    def test__query_result_by_part_number__matches_expected(
+    def test__query_result_by_part_number_and_serial_number_with_projection__results_with_only_projected_fields(
         self, client: TestMonitorClient, create_results, unique_identifier
     ):
-        part_number = unique_identifier
-        program_name = "Test Program"
-        status = Status.PASSED()
         results = [
             CreateResultRequest(
-                part_number=part_number, program_name=program_name, status=status
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
+                serial_number=unique_identifier,
+                status=Status.PASSED(),
+            )
+        ]
+        create_response: CreateResultsPartialSuccess = create_results(results)
+        assert create_response is not None
+
+        query_request = QueryResultsRequest(
+            filter=f'partNumber="{results[0].part_number}" and serialNumber="{results[0].serial_number}"',
+            projection=[
+                ResultProjection.ID,
+                ResultProjection.PART_NUMBER,
+                ResultProjection.SERIAL_NUMBER,
+            ],
+            return_count=True,
+        )
+        query_response: PagedResults = client.query_results(query_request)
+
+        assert query_response.total_count == 1
+        assert len(query_response.results) == 1
+        assert query_response.results[0].part_number == results[0].part_number
+        assert query_response.results[0].serial_number == results[0].serial_number
+        assert set(query_response.results[0].__fields_set__) == {
+            "id",
+            "part_number",
+            "serial_number",
+        }
+
+    def test__query_result_values_for_program_name__name_matches(
+        self, client: TestMonitorClient, create_results, unique_identifier
+    ):
+        results = [
+            CreateResultRequest(
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
+                serial_number=unique_identifier,
+                status=Status.PASSED(),
             )
         ]
 
         create_response: CreateResultsPartialSuccess = create_results(results)
-
-        assert create_response is not None
-        query_request = QueryResultsRequest(
-            filter=f'partNumber="{part_number}"', return_count=True
-        )
-        query_response: PagedResults = client.query_results(query_request)
-        assert query_response.total_count == 1
-        assert query_response.results[0].part_number == part_number
-
-    def test__query_result_values_for_name__name_matches(
-        self, client: TestMonitorClient, create_results, unique_identifier
-    ):
-        part_number = unique_identifier
-        program_name = "Test Program"
-        status = Status.PASSED()
-
-        create_response: CreateResultsPartialSuccess = create_results(
-            [
-                CreateResultRequest(
-                    part_number=part_number, program_name=program_name, status=status
-                )
-            ]
-        )
         assert create_response is not None
         query_request = QueryResultValuesRequest(
-            filter=f'partNumber="{part_number}"', field=ResultField.PROGRAM_NAME
+            filter=f'partNumber="{results[0].part_number}" and serialNumber="{results[0].serial_number}"',
+            field=ResultField.PROGRAM_NAME,
         )
         query_response: List[str] = client.query_result_values(query_request)
 
         assert query_response is not None
         assert len(query_response) == 1
-        assert query_response[0] == program_name
+        assert query_response[0] == results[0].program_name
 
     def test__update_keywords_with_replace__keywords_replaced(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
         original_keyword = "originalKeyword"
         updated_keyword = "updatedKeyword"
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(
-                    part_number=unique_identifier,
+                    part_number="Python Client Testing",
                     keywords=[original_keyword],
                     program_name=program_name,
                     status=status,
@@ -345,16 +367,16 @@ class TestTestMonitor:
         assert original_keyword not in update_response.results[0].keywords
 
     def test__update_keywords_no_replace__keywords_appended(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
         original_keyword = "originalKeyword"
         additional_keyword = "additionalKeyword"
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(
-                    part_number=unique_identifier,
+                    part_number="Python Client Testing",
                     keywords=[original_keyword],
                     program_name=program_name,
                     status=status,
@@ -382,17 +404,17 @@ class TestTestMonitor:
         )
 
     def test__update_properties_with_replace__properties_replaced(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
         new_key = "newKey"
         original_properties = {"originalKey": "originalValue"}
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         new_properties: Dict[str, Optional[str]] = {new_key: "newValue"}
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(
-                    part_number=unique_identifier,
+                    part_number="Python Client Testing",
                     properties=original_properties,
                     program_name=program_name,
                     status=status,
@@ -418,18 +440,18 @@ class TestTestMonitor:
         assert update_response.results[0].properties[new_key] == new_properties[new_key]
 
     def test__update_properties_append__properties_appended(
-        self, client: TestMonitorClient, create_results, unique_identifier
+        self, client: TestMonitorClient, create_results
     ):
         original_key = "originalKey"
         new_key = "newKey"
         original_properties = {original_key: "originalValue"}
-        program_name = "Test Program"
+        program_name = "Python Client Test Program"
         status = Status.PASSED()
         new_properties: Dict[str, Optional[str]] = {new_key: "newValue"}
         create_response: CreateResultsPartialSuccess = create_results(
             [
                 CreateResultRequest(
-                    part_number=unique_identifier,
+                    part_number="Python Client Testing",
                     properties=original_properties,
                     program_name=program_name,
                     status=status,
@@ -472,8 +494,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -513,12 +535,12 @@ class TestTestMonitor:
         assert not created_step.outputs
 
     def test__create_multiple_steps__multiple_creation_succeed(
-        self, client: TestMonitorClient, create_results, create_steps, unique_identifier
+        self, client: TestMonitorClient, create_results, create_steps
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -543,12 +565,12 @@ class TestTestMonitor:
         assert len(response.steps) == 2
 
     def test__create_multiple_steps_with_children__multiple_creation_succeed(
-        self, client: TestMonitorClient, create_results, create_steps, unique_identifier
+        self, client: TestMonitorClient, create_results, create_steps
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -583,8 +605,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -609,8 +631,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -640,8 +662,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -671,8 +693,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -694,8 +716,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -728,8 +750,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -758,8 +780,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -866,8 +888,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -914,8 +936,8 @@ class TestTestMonitor:
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]
@@ -950,12 +972,12 @@ class TestTestMonitor:
             )
 
     def test__delete_multiple_steps__deletion_succeed(
-        self, client: TestMonitorClient, create_results, create_steps, unique_identifier
+        self, client: TestMonitorClient, create_results, create_steps
     ):
         results = [
             CreateResultRequest(
-                part_number=unique_identifier,
-                program_name="Test Program",
+                part_number="Python Client Testing",
+                program_name="Python Client Test Program",
                 status=Status.PASSED(),
             )
         ]

--- a/tests/integration/testmonitor/test_testmonitor.py
+++ b/tests/integration/testmonitor/test_testmonitor.py
@@ -7,7 +7,7 @@ from nisystemlink.clients.core._http_configuration import HttpConfiguration
 from nisystemlink.clients.product._product_client import ProductClient
 from nisystemlink.clients.product.models._query_products_request import (
     ProductField,
-    QueryProductValuesRequest
+    QueryProductValuesRequest,
 )
 from nisystemlink.clients.testmonitor import TestMonitorClient
 from nisystemlink.clients.testmonitor.models import (
@@ -75,15 +75,20 @@ def create_results(client: TestMonitorClient, product_client: ProductClient):
         if response.results:
             created_results = created_results + response.results
 
-    part_numbers_of_created_products = list(set(result.part_number for result in created_results))
+    part_numbers_of_created_products = list(
+        set(result.part_number for result in created_results)
+    )
 
     client.delete_results(ids=[str(result.id) for result in created_results])
 
-    filter_string = " or ".join([f'partNumber="{part_number}"' for part_number in part_numbers_of_created_products])
+    filter_string = " or ".join(
+        [
+            f'partNumber="{part_number}"'
+            for part_number in part_numbers_of_created_products
+        ]
+    )
     created_product_ids = product_client.query_product_values(
-        QueryProductValuesRequest(
-            filter=filter_string, field=ProductField.ID
-        )
+        QueryProductValuesRequest(filter=filter_string, field=ProductField.ID)
     )
 
     product_client.delete_products(ids=created_product_ids)


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In the Result Client test cases, a [fixture](https://github.com/ni/nisystemlink-clients-python/blob/820df0e39bea16dfe9f8bc5fad21a57efbb0194b/tests/integration/testmonitor/test_testmonitor.py#L49) is used to create results with a dummy part number. As per the design of the create-results API in SLE, a product is created with that dummy part number. This product should be deleted in the fixture itself once the linked results are deleted.

Implementation - All the products created during a test case are deleted by the fixture.

### Why should this Pull Request be merged?

As the test suites are executed in the pipeline, the tests are continuously run which ended up polluting the test environment.

### What testing has been done?

Verified the existing cases are passing