### PR TITLE
chore: Update package metadata and contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
 for more details.
 
 **Important:** Commit titles and messages should adhere to the
-[Angular style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
+[Conventional Commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 to ensure proper semantic versioning.
 
 ## Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ version = "2.6.0"
 description = "NI-SystemLink Python API"
 authors = ["National Instruments"]
 maintainers = [
-    "Carson Moore <carson.moore@ni.com>",
-    "Paul Spangler <paul.spangler@ni.com>",
-    "Cameron Waterman <cameron.waterman@ni.com>",
+    "Richard Bell <richard.bell@emerson.com>",
+    "Paul Spangler <paul.spangler@emerson.com>",
+    "Cameron Waterman <cameron.waterman@emerson.com>",
 ]
 keywords = ["nisystemlink", "systemlink"]
 license = "MIT"
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Hardware",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Updates maintainers 
- Points commit style to Conventional Commits instead of Angular
- Includes Python 3.13 in capabilities

### Why should this Pull Request be merged?

- The owners have changed and our email addresses need updates
- Conventional Commits and Angular commits have the same style, but Conventional Commits has better documentation and is more specifically the style used by the commit parser
- We support python 3.13 and it should be documented as such

### What testing has been done?

Chore change
