### PR TITLE
fix: Add 429 retries to notebook client

### DIFF
--- a/nisystemlink/clients/notebook/_notebook_client.py
+++ b/nisystemlink/clients/notebook/_notebook_client.py
@@ -15,7 +15,7 @@ from nisystemlink.clients.core._uplink._methods import (
 )
 from nisystemlink.clients.core.helpers._iterator_file_like import IteratorFileLike
 from requests.models import Response
-from uplink import Part, Path
+from uplink import Part, Path, retry
 
 from . import models
 
@@ -36,6 +36,7 @@ def _simple_response_handler(response: Response) -> dict:
     return response.json()
 
 
+@retry(when=retry.when.status(429), stop=retry.stop.after_attempt(5))
 class NotebookClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds retries to the notebook client for 429 rate limited responses, similar to other clients

### Why should this Pull Request be merged?

The notebook integration tests will fail intermittently with 429 responses and this will make the tests more robust. This is also a generally nice to have improvement to the client that we have on other clients.

### What testing has been done?

The integration tests are passing locally
