### PR TITLE
test: Reduce parallel jobs on CI pipeline runs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+      # Limit parallel runs on pushes to master to 1 to limit integration test rate limited failures
+      max-parallel: ${{ github.event_name == 'pull_request' && 5 || 1 }}
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Set the maximum number of parallel python test jobs to 1 when running on the CI, while keeping it at 5 (number of python versions in the matrix) when running on PRs.

### Why should this Pull Request be merged?

The CI is failing due to rate limiting, even with the clients retrying 429 responses. I believe this is due to each job sharing an API key and running parallel, effectively 5x-ing the number of requests made by the tests. 

### What testing has been done?

The job syntax will be validated by the PR.
