### PR TITLE
chore: two typos in the `testmonitor` examples

### DIFF
--- a/examples/testmonitor/results.py
+++ b/examples/testmonitor/results.py
@@ -37,7 +37,7 @@ def create_some_results():
     return create_response
 
 
-# Server configuration is not required when used with Systemlink Client or run throught Jupyter on SLE
+# Server configuration is not required when used with SystemLink Client or run through Jupyter on SystemLink
 server_configuration = None
 
 # # Example of setting up the server configuration to point to your instance of SystemLink Enterprise


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes two minor typos in the examples for `testmonitor`.

### Why should this Pull Request be merged?

Cleanup.

### What testing has been done?

Update to comments only. Does not require additional testing. 
