### PR TITLE
feat: Add retry handling to DataFrameClient

### DIFF
--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -18,7 +18,7 @@ from uplink import Body, Field, Path, Query, retry
 from . import models
 
 
-# retry for common status codes and any Connection error 
+# retry for common http status codes and any Connection error 
 @retry(
     when=retry.when.status([429, 502, 503, 504]),
     stop=retry.stop.after_attempt(5),

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -19,7 +19,7 @@ from . import models
 
 
 @retry(
-    when=retry.when.status([429, 500, 502, 503, 504]),
+    when=retry.when.status([429, 502, 503, 504]),
     stop=retry.stop.after_attempt(5),
     on_exception=retry.CONNECTION_ERROR,
 )

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -18,6 +18,7 @@ from uplink import Body, Field, Path, Query, retry
 from . import models
 
 
+# retry for common status codes and any Connection error 
 @retry(
     when=retry.when.status([429, 502, 503, 504]),
     stop=retry.stop.after_attempt(5),

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -13,11 +13,16 @@ from nisystemlink.clients.core._uplink._methods import (
 )
 from nisystemlink.clients.core.helpers import IteratorFileLike
 from requests.models import Response
-from uplink import Body, Field, Path, Query
+from uplink import Body, Field, Path, Query, retry
 
 from . import models
 
 
+@retry(
+    when=retry.when.status([429, 500, 502, 503, 504]),
+    stop=retry.stop.after_attempt(5),
+    on_exception=retry.CONNECTION_ERROR,
+)
 class DataFrameClient(BaseClient):
     def __init__(self, configuration: Optional[core.HttpConfiguration] = None):
         """Initialize an instance.

--- a/nisystemlink/clients/dataframe/_data_frame_client.py
+++ b/nisystemlink/clients/dataframe/_data_frame_client.py
@@ -18,7 +18,7 @@ from uplink import Body, Field, Path, Query, retry
 from . import models
 
 
-# retry for common http status codes and any Connection error 
+# retry for common http status codes and any Connection error
 @retry(
     when=retry.when.status([429, 502, 503, 504]),
     stop=retry.stop.after_attempt(5),


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds retry decorator to `DataFrameClient` to handle common http status codes and connection errors.

### Why should this Pull Request be merged?

Simplify developer experience in terms of handling common error situations

### What testing has been done?

Existing automated Tests
