### PR TITLE
test: Stop running test in parallel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-      max-parallel: 1
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
           --enterprise-uri "https://test-api.lifecyclesolutions.ni.com" --enterprise-api-key "${{ secrets.ENTERPRISE_API_KEY }}"
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-lint-unit-test, integration-test]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-      # Limit parallel runs on pushes to master to 1 to limit integration test rate limited failures
-      max-parallel: ${{ github.event_name == 'pull_request' && 5 || 1 }}
+      # Do not run in parallel to limit parallel integration tests stomping on each other
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,26 @@ on:
     branches: [master, main]
 
 jobs:
-  build:
+  build-lint-unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
+      - run: poetry install
+      - run: poetry run poe test
+      - run: poetry run poe check
+      - run: poetry run poe lint
+      - run: poetry run poe types
+  integration-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,11 +44,9 @@ jobs:
       - run: poetry install
       - run: >
           poetry run pytest
+          -m integration
           --cloud-api-key "${{ secrets.CLOUD_API_KEY }}"
           --enterprise-uri "https://test-api.lifecyclesolutions.ni.com" --enterprise-api-key "${{ secrets.ENTERPRISE_API_KEY }}"
-      - run: poetry run poe check
-      - run: poetry run poe lint
-      - run: poetry run poe types
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/tests/product/test_product_dataframe_utilities.py
+++ b/tests/product/test_product_dataframe_utilities.py
@@ -70,7 +70,6 @@ def empty_products_data() -> List:
     return []
 
 
-@pytest.mark.enterprise
 @pytest.mark.unit
 class TestProductDataframeUtilities:
     def test__convert_products_to_dataframe__with_complete_data(

--- a/tests/spec/test_spec_dataframe_utilitites.py
+++ b/tests/spec/test_spec_dataframe_utilitites.py
@@ -117,7 +117,6 @@ def specs() -> List[Specification]:
     return specs
 
 
-@pytest.mark.enterprise
 @pytest.mark.unit
 class TestSpecDataframeUtilities:
     def test__convert_specs_to_dataframe_with_summarize_conditions__returns_specs_dataframe_with_string_conditions(

--- a/tests/testmonitor/test_testmonitor_dataframe_utilities.py
+++ b/tests/testmonitor/test_testmonitor_dataframe_utilities.py
@@ -195,7 +195,6 @@ def empty_steps_data() -> List:
     return []
 
 
-@pytest.mark.enterprise
 @pytest.mark.unit
 class TestTestmonitorDataframeUtilities:
     def test__convert_results_with_all_fields_to_dataframe__returns_whole_results_dataframe(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Splits integration tests out into a separate job that runs with no parallelization
- Runs only unit tests in the main build job
- Updates some tests incorrectly marked enterprise

### Why should this Pull Request be merged?

Integration tests modify shared state in the test environment and then running at the same time across python versions is causing intermittent test failures

### What testing has been done?

PR
