### PR TITLE
fix: make testmonitor step examples show up in docs and fix `update_results` example

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -286,7 +286,7 @@ Create, update, query, and delete steps
 
 .. literalinclude:: ../examples/testmonitor/steps.py
    :language: python
-   :linenos
+   :linenos:
 
 Notebook API
 -------

--- a/examples/testmonitor/results.py
+++ b/examples/testmonitor/results.py
@@ -6,6 +6,7 @@ from nisystemlink.clients.testmonitor.models import (
     ResultField,
     Status,
     StatusType,
+    UpdateResultRequest,
 )
 
 program_name = "Example Name"
@@ -70,9 +71,12 @@ response = client.query_results(query_request)
 
 # Update the first result that you just created and replace the keywords
 updated_result = create_response.results[0]
-updated_result.keywords = ["new keyword"]
-updated_result.properties = {"new property key": "new value"}
-update_response = client.update_results([create_response.results[0]], replace=True)
+updated_result = UpdateResultRequest(
+    id=create_response.results[0].id,
+    keywords=["new keyword"],
+    properties={"new property key": "new value"},
+)
+update_response = client.update_results([updated_result], replace=True)
 
 # Query for just the ids of results that match the family
 values_query = QueryResultValuesRequest(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. The steps example was not showing up in the getting started section of the documentation. 
2. The example for updating results was wrong. You can't use the return value from `create` to do an `update`.

### Why should this Pull Request be merged?

Cleanup docs and fix example

### What testing has been done?

Example code was tested locally. 
