### PR TITLE
fix: Make condition type optional while querying specs

### DIFF
--- a/nisystemlink/clients/spec/models/_condition.py
+++ b/nisystemlink/clients/spec/models/_condition.py
@@ -30,7 +30,7 @@ class ConditionRange(JsonModel):
 class ConditionValueBase(JsonModel):
     """The base type for conditions that can be represented in several styles."""
 
-    condition_type: ConditionType
+    condition_type: Optional[ConditionType]
     """Type of the Condition."""
 
 

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -298,7 +298,7 @@ class TestSpec:
         assert "spec_id" in spec_columns
         assert "name" in spec_columns
 
-    def test_query_spec_projection_condition_columns_no_condition_type_returns_columns(
+    def test_query_specs_without_condition_type_projection_condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product
     ):
         request = QuerySpecificationsRequest(

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -298,7 +298,7 @@ class TestSpec:
         assert "spec_id" in spec_columns
         assert "name" in spec_columns
 
-    def test_query_specs_without_condition_type_projection_condition_type_field_is_unset(
+    def test__without_condition_type_projection__query_specs__condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product
     ):
         request = QuerySpecificationsRequest(
@@ -323,6 +323,7 @@ class TestSpec:
             is not None
         }
 
+        assert response.specs
         assert len(response.specs) == 3
         assert len(spec_columns) == 2
         assert "condition_name" in spec_columns


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Made `condition_type` optional when querying specs, allowing the use of projections in conditions without requiring a `condition_type`.

### Why should this Pull Request be merged?

To enable the use of querying conditions without requiring a `condition_type`. 

### What testing has been done?

Added a separate test. 
