### PR TITLE
feat: Make TLS/SSL certificate verification optional

### DIFF
--- a/examples/general/disable_cert_verify.py
+++ b/examples/general/disable_cert_verify.py
@@ -1,0 +1,11 @@
+"""Example to demonstrate disabling TLS/SSL certificate verification for connections"""
+
+from nisystemlink.clients.core import HttpConfigurationManager
+from nisystemlink.clients.file import FileClient
+
+# explicitly get the http config and set the verify option
+http_config = HttpConfigurationManager.get_configuration()
+http_config.verify = False
+
+client = FileClient(configuration=http_config)
+print(client.api_info())

--- a/nisystemlink/clients/core/_http_configuration.py
+++ b/nisystemlink/clients/core/_http_configuration.py
@@ -41,7 +41,7 @@ class HttpConfiguration:
             password: The user's password to use when authorization is required.
             cert_path: Local path to an SSL certificate file.
             workspace: ID of workspace to use for client operations.
-            verify: Verify the securicty certificate for connection
+            verify: Verify the security certificate for connection
 
         Raises:
             ValueError: if ``server_uri`` is missing scheme or host information.

--- a/nisystemlink/clients/core/_http_configuration.py
+++ b/nisystemlink/clients/core/_http_configuration.py
@@ -23,6 +23,7 @@ class HttpConfiguration:
         password: Optional[str] = None,
         cert_path: Optional[pathlib.Path] = None,
         workspace: Optional[str] = None,
+        verify: bool = True,
     ) -> None:
         """Initialize a configuration.
 
@@ -40,6 +41,7 @@ class HttpConfiguration:
             password: The user's password to use when authorization is required.
             cert_path: Local path to an SSL certificate file.
             workspace: ID of workspace to use for client operations.
+            verify: Verify the securicty certificate for connection
 
         Raises:
             ValueError: if ``server_uri`` is missing scheme or host information.
@@ -72,6 +74,17 @@ class HttpConfiguration:
         self._timeout_ms = self.DEFAULT_TIMEOUT_MILLISECONDS
 
         self._workspace = workspace
+
+        self._verify = verify
+
+    @property
+    def verify(self) -> bool:
+        """Verify the security certificate for connection."""
+        return self._verify
+
+    @verify.setter
+    def verify(self, value: bool) -> None:
+        self._verify = value
 
     @property
     def timeout_milliseconds(self) -> int:  # noqa: D401

--- a/nisystemlink/clients/core/_uplink/_base_client.py
+++ b/nisystemlink/clients/core/_uplink/_base_client.py
@@ -3,6 +3,7 @@
 from json import loads
 from typing import Any, Callable, Dict, get_origin, Optional, Type, Union
 
+import requests
 from nisystemlink.clients import core
 from pydantic import parse_obj_as
 from requests import JSONDecodeError, Response
@@ -79,10 +80,14 @@ class BaseClient(Consumer):
             configuration: Defines the web server to connect to and information about how to connect.
             base_path: The base path for all API calls.
         """
+        session = requests.Session()
+        session.verify = configuration.verify
+
         super().__init__(
             base_url=configuration.server_uri + base_path,
             converter=_JsonModelConverter(),
             hooks=[_handle_http_status],
+            client=session,
         )
         if configuration.api_keys:
             self.session.headers.update(configuration.api_keys)


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Explicitly use the `requests` as the communication client package for `uplink` and expose the `requests.verify` to the user through `HttpConfiguration`

### Why should this Pull Request be merged?

Allow SLE users with private CA to use the `systemlink-clients` package.

### What testing has been done?

Automated tests.
