### PR TITLE
fix: Convert condition type to string in SpecDataFrame utilities

### DIFF
--- a/nisystemlink/clients/spec/utilities/_constants.py
+++ b/nisystemlink/clients/spec/utilities/_constants.py
@@ -1,6 +1,30 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from nisystemlink.clients.spec.models._condition import ConditionRange
+
+
 class DataFrameHeaders:
     CONDITION_COLUMN_HEADER_PREFIX = "condition_"
 
     PROPERTY_COLUMN_HEADER_PREFIX = "properties."
 
     KEYWORDS_COLUMN_HEADER = "keywords"
+
+
+@dataclass
+class TempNumericCondition:
+    """A temp numeric condition to store condition type as string."""
+
+    condition_type: str
+    range: Optional[List[ConditionRange]] = None
+    discrete: Optional[List[float]] = None
+    unit: Optional[str] = None
+
+
+@dataclass
+class TempStringCondition:
+    """A temp string condition to store condition type as string."""
+
+    condition_type: str
+    discrete: Optional[List[str]] = None

--- a/tests/spec/test_spec_dataframe_utilitites.py
+++ b/tests/spec/test_spec_dataframe_utilitites.py
@@ -17,6 +17,10 @@ from nisystemlink.clients.spec.models._specification import (
     SpecificationType,
 )
 from nisystemlink.clients.spec.utilities import convert_specs_to_dataframe
+from nisystemlink.clients.spec.utilities._constants import (
+    TempNumericCondition,
+    TempStringCondition,
+)
 from nisystemlink.clients.spec.utilities._dataframe_utilities import (
     normalize_conditions_per_column,
     normalize_conditions_per_row,
@@ -276,16 +280,16 @@ class TestSpecDataframeUtilities:
         conditions_dict = [
             [
                 {
-                    "condition_Temperature": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Temperature": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                         ],
                         discrete=[1.3, 1.5, 1.7],
                         unit="C",
                     ),
-                    "condition_Package": StringConditionValue(
-                        condition_type=ConditionType.STRING,
+                    "condition_Package": TempStringCondition(
+                        condition_type=ConditionType.STRING.value,
                         discrete=["D", "QFIN"],
                     ),
                     "condition_Supply Voltage": None,
@@ -293,8 +297,8 @@ class TestSpecDataframeUtilities:
             ],
             [
                 {
-                    "condition_Temperature": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Temperature": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                             ConditionRange(min=-10, step=10),
@@ -302,8 +306,8 @@ class TestSpecDataframeUtilities:
                         unit="C",
                     ),
                     "condition_Package": None,
-                    "condition_Supply Voltage": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Supply Voltage": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         discrete=[1.3, 1.5, 1.7],
                         unit="mV",
                     ),
@@ -356,8 +360,8 @@ class TestSpecDataframeUtilities:
             [
                 {
                     "condition.name": "Temperature",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                         ],
@@ -367,8 +371,8 @@ class TestSpecDataframeUtilities:
                 },
                 {
                     "condition.name": "Package",
-                    "condition.value": StringConditionValue(
-                        condition_type=ConditionType.STRING,
+                    "condition.value": TempStringCondition(
+                        condition_type=ConditionType.STRING.value,
                         discrete=["D", "QFIN"],
                     ),
                 },
@@ -376,8 +380,8 @@ class TestSpecDataframeUtilities:
             [
                 {
                     "condition.name": "Temperature",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                             ConditionRange(min=-10, step=10),
@@ -387,8 +391,8 @@ class TestSpecDataframeUtilities:
                 },
                 {
                     "condition.name": "Supply Voltage",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         discrete=[1.3, 1.5, 1.7],
                         unit="mV",
                     ),
@@ -490,32 +494,32 @@ class TestSpecDataframeUtilities:
         expected_conditions_dict = [
             [
                 {
-                    "condition_Temperature": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Temperature": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                         ],
                         discrete=[1.3, 1.5, 1.7],
                         unit="C",
                     ),
-                    "condition_Package": StringConditionValue(
-                        condition_type=ConditionType.STRING,
+                    "condition_Package": TempStringCondition(
+                        condition_type=ConditionType.STRING.value,
                         discrete=["D", "QFIN"],
                     ),
                 }
             ],
             [
                 {
-                    "condition_Temperature": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Temperature": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                             ConditionRange(min=-10, step=10),
                         ],
                         unit="C",
                     ),
-                    "condition_Supply Voltage": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition_Supply Voltage": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         discrete=[1.3, 1.5, 1.7],
                         unit="mV",
                     ),
@@ -538,8 +542,8 @@ class TestSpecDataframeUtilities:
             [
                 {
                     "condition.name": "Temperature",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                         ],
@@ -549,8 +553,8 @@ class TestSpecDataframeUtilities:
                 },
                 {
                     "condition.name": "Package",
-                    "condition.value": StringConditionValue(
-                        condition_type=ConditionType.STRING,
+                    "condition.value": TempStringCondition(
+                        condition_type=ConditionType.STRING.value,
                         discrete=["D", "QFIN"],
                     ),
                 },
@@ -558,8 +562,8 @@ class TestSpecDataframeUtilities:
             [
                 {
                     "condition.name": "Temperature",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         range=[
                             ConditionRange(min=-25, step=20, max=85),
                             ConditionRange(min=-10, step=10),
@@ -569,8 +573,8 @@ class TestSpecDataframeUtilities:
                 },
                 {
                     "condition.name": "Supply Voltage",
-                    "condition.value": NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
+                    "condition.value": TempNumericCondition(
+                        condition_type=ConditionType.NUMERIC.value,
                         discrete=[1.3, 1.5, 1.7],
                         unit="mV",
                     ),


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes an issue by converting condition types to strings in SpecDataFrame utilities for easy accessibility.

### Why should this Pull Request be merged?

Ensures proper data handling to access the condition types more easily.

### What testing has been done?

Updated the existing test