### PR TITLE
fix: Prevent string discrete values which are string of numbers from passing as numeric condition values.

### DIFF
--- a/nisystemlink/clients/spec/models/_condition.py
+++ b/nisystemlink/clients/spec/models/_condition.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from nisystemlink.clients.core._uplink._json_model import JsonModel
-from pydantic import StrictStr
+from pydantic import StrictFloat, StrictInt, StrictStr
 
 
 class ConditionType(Enum):
@@ -44,7 +44,10 @@ class NumericConditionValue(ConditionValueBase):
     range: Optional[List[ConditionRange]] = None
     """List of condition range values."""
 
-    discrete: Optional[List[float]] = None
+    # StrictFloat and StrictInt are used here because discrete is a common property for
+    # NumericConditionValue and StringConditionValue.
+    # And pydantic converts string of number into float/int by default if just float/int is used
+    discrete: Optional[List[Union[StrictFloat, StrictInt]]] = None
     """List of condition discrete values."""
 
     unit: Optional[str] = None
@@ -57,6 +60,9 @@ class StringConditionValue(ConditionValueBase):
     String conditions may only contain discrete lists of values.
     """
 
+    # StrictStr is used here because discrete is a common property for
+    # NumericConditionValue and StringConditionValue.
+    # And pydantic converts any datatype into string by default if just str is used.
     discrete: Optional[List[StrictStr]] = None
     """List of condition discrete values."""
 
@@ -67,5 +73,5 @@ class Condition(JsonModel):
     name: Optional[str] = None
     """Name of the condition."""
 
-    value: Optional[Union[StringConditionValue, NumericConditionValue]] = None
+    value: Optional[Union[NumericConditionValue, StringConditionValue]] = None
     """Value of the condition."""

--- a/nisystemlink/clients/spec/models/_condition.py
+++ b/nisystemlink/clients/spec/models/_condition.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from nisystemlink.clients.core._uplink._json_model import JsonModel
+from pydantic import StrictStr
 
 
 class ConditionType(Enum):
@@ -56,7 +57,7 @@ class StringConditionValue(ConditionValueBase):
     String conditions may only contain discrete lists of values.
     """
 
-    discrete: Optional[List[str]] = None
+    discrete: Optional[List[StrictStr]] = None
     """List of condition discrete values."""
 
 
@@ -66,5 +67,5 @@ class Condition(JsonModel):
     name: Optional[str] = None
     """Name of the condition."""
 
-    value: Optional[Union[NumericConditionValue, StringConditionValue]] = None
+    value: Optional[Union[StringConditionValue, NumericConditionValue]] = None
     """Value of the condition."""

--- a/nisystemlink/clients/spec/models/_condition.py
+++ b/nisystemlink/clients/spec/models/_condition.py
@@ -46,7 +46,8 @@ class NumericConditionValue(ConditionValueBase):
 
     # StrictFloat and StrictInt are used here because discrete is a common property for
     # NumericConditionValue and StringConditionValue.
-    # And pydantic converts string of number into float/int by default if just float/int is used
+    # If float/int is used, pydantic converts string of number into float/int by default
+    # when deserializing a StringCondition JSON and misinterprets it as NumericConditionValue type.
     discrete: Optional[List[Union[StrictFloat, StrictInt]]] = None
     """List of condition discrete values."""
 
@@ -62,7 +63,8 @@ class StringConditionValue(ConditionValueBase):
 
     # StrictStr is used here because discrete is a common property for
     # NumericConditionValue and StringConditionValue.
-    # And pydantic converts any datatype into string by default if just str is used.
+    # If str is used, pydantic converts any datatype into string by default when deserializing a
+    # NumericCondition JSON and misinterprets it as StringConditionValue type.
     discrete: Optional[List[StrictStr]] = None
     """List of condition discrete values."""
 
@@ -73,5 +75,8 @@ class Condition(JsonModel):
     name: Optional[str] = None
     """Name of the condition."""
 
+    # Ideal approach is to set the dtype here as ConditionValue and use pydantic discriminator to
+    # deserialize/serialize the JSON into correct ConditionValue sub types. But Union of dtypes is
+    # used here as the discriminator field could be none when projection is used in query API.
     value: Optional[Union[NumericConditionValue, StringConditionValue]] = None
     """Value of the condition."""

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -313,8 +313,18 @@ class TestSpec:
 
         assert response.specs
         assert len(response.specs) == 3
-        assert isinstance(response.specs[1].conditions[0].value, NumericConditionValue)
-        assert isinstance(response.specs[1].conditions[1].value, StringConditionValue)
+        condition_1 = (
+            response.specs[1].conditions[0].value
+            if response.specs[1].conditions
+            else None
+        )
+        condition_2 = (
+            response.specs[1].conditions[1].value
+            if response.specs[1].conditions
+            else None
+        )
+        assert isinstance(condition_1, NumericConditionValue)
+        assert isinstance(condition_2, StringConditionValue)
 
     def test__without_condition_type_projection__query_specs__condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -84,6 +84,7 @@ def create_specs_for_query(create_specs, product):
                     value=NumericConditionValue(
                         condition_type=ConditionType.NUMERIC,
                         range=[ConditionRange(min=-25, step=20, max=85)],
+                        discrete=[2, 1.5, 21],
                         unit="C",
                     ),
                 ),

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -327,6 +327,12 @@ class TestSpec:
         )
         assert isinstance(condition_1, NumericConditionValue)
         assert isinstance(condition_2, StringConditionValue)
+        assert isinstance(condition_1.discrete[0], int)
+        assert isinstance(condition_1.discrete[1], float)
+        assert isinstance(condition_1.discrete[2], int)
+        assert isinstance(condition_2.discrete[0], str)
+        assert isinstance(condition_2.discrete[1], str)
+        assert isinstance(condition_2.discrete[2], str)
 
     def test__without_condition_type_projection__query_specs__condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -17,6 +17,7 @@ from nisystemlink.clients.spec.models import (
     SpecificationLimit,
     SpecificationProjection,
     SpecificationType,
+    StringConditionValue,
     UpdateSpecificationsRequest,
     UpdateSpecificationsRequestObject,
 )
@@ -88,10 +89,9 @@ def create_specs_for_query(create_specs, product):
                 ),
                 Condition(
                     name="Supply Voltage",
-                    value=NumericConditionValue(
-                        condition_type=ConditionType.NUMERIC,
-                        discrete=[1.3, 1.5, 1.7],
-                        unit="mV",
+                    value=StringConditionValue(
+                        condition_type=ConditionType.STRING,
+                        discrete=["1.3", "1.5", "1.7"],
                     ),
                 ),
             ],
@@ -297,6 +297,24 @@ class TestSpec:
         assert len(spec_columns) == 2
         assert "spec_id" in spec_columns
         assert "name" in spec_columns
+
+    def test__query_specs__returns_condition_value_type_correctly(
+        self, client: SpecClient, create_specs, create_specs_for_query, product
+    ):
+        request = QuerySpecificationsRequest(
+            product_ids=[product],
+            projection=[
+                SpecificationProjection.CONDITION_NAME,
+                SpecificationProjection.CONDITION_UNIT,
+            ],
+        )
+
+        response = client.query_specs(request)
+
+        assert response.specs
+        assert len(response.specs) == 3
+        assert isinstance(response.specs[1].conditions[0].value, NumericConditionValue)
+        assert isinstance(response.specs[1].conditions[1].value, StringConditionValue)
 
     def test__without_condition_type_projection__query_specs__condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -307,6 +307,7 @@ class TestSpec:
             projection=[
                 SpecificationProjection.CONDITION_NAME,
                 SpecificationProjection.CONDITION_UNIT,
+                SpecificationProjection.CONDITION_VALUES,
             ],
         )
 

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -325,14 +325,20 @@ class TestSpec:
             if response.specs[1].conditions
             else None
         )
+        condition_1_discrete_values = (
+            [discrete for discrete in condition_1.discrete or []] if condition_1 else []
+        )
+        condition_2_discrete_values = (
+            [discrete for discrete in condition_2.discrete or []] if condition_2 else []
+        )
         assert isinstance(condition_1, NumericConditionValue)
         assert isinstance(condition_2, StringConditionValue)
-        assert isinstance(condition_1.discrete[0], int)
-        assert isinstance(condition_1.discrete[1], float)
-        assert isinstance(condition_1.discrete[2], int)
-        assert isinstance(condition_2.discrete[0], str)
-        assert isinstance(condition_2.discrete[1], str)
-        assert isinstance(condition_2.discrete[2], str)
+        assert isinstance(condition_1_discrete_values[0], int)
+        assert isinstance(condition_1_discrete_values[1], float)
+        assert isinstance(condition_1_discrete_values[2], int)
+        assert isinstance(condition_2_discrete_values[0], str)
+        assert isinstance(condition_2_discrete_values[1], str)
+        assert isinstance(condition_2_discrete_values[2], str)
 
     def test__without_condition_type_projection__query_specs__condition_type_field_is_unset(
         self, client: SpecClient, create_specs, create_specs_for_query, product


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- It makes sure that string discrete values are correctly passing as string condition values numeric discrete values are correctly passing as numeric condition values.
- Data type of `discrete` value of `NumericConditionValue` is set to `List[Union[StringFloat, StrictInt]]`. Used StrictFloat and StrictInt because we only need integer and float values to be stored here and not string of numbers. If `int`/`float` are used, pydantic tries to convert the string of numbers into float/int.
- Data type of `discrete` value of `StringConditionValue` is set to `StrictStr`. Used `StrictStr` beause, we only want strings to be stored here and not any other datatypes. If `str` is used, pydantic converts any other datatypes to string and stores it.

### Why should this Pull Request be merged?

- String discrete values which has string of numbers are being converted into numeric condition values.
- This PR has changes which converts such discrete values correctly as string condition values. And also makes sure that real numeric discrete values are being converted into numeric condition values.

### What testing has been done?

Automated integration tests are included.
