### PR TITLE
fix: Ignore extra fields in Json Model

### DIFF
--- a/nisystemlink/clients/core/_uplink/_json_model.py
+++ b/nisystemlink/clients/core/_uplink/_json_model.py
@@ -13,4 +13,4 @@ class JsonModel(BaseModel):
     class Config:
         alias_generator = _camelcase
         allow_population_by_field_name = True
-        extra = Extra.ignore
+        extra = Extra.ignore.value


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Ignoring extra fields from the API response was wrongly set before in the `Config` class of the `JsonModel`.
- Changes the extra value from `Extra.ignore` to `Extra.ignore.value`, so that `string` is used instead of `Enum`.

### Why should this Pull Request be merged?

- Pydantic model validation error was occurring before due to incorrect ignore configuration for extra values in the `JsonModel`.
- After merging this PR, extra values from the API responses will be ignored by pydantic.

### What testing has been done?

Existing automated tests.
