### PR TITLE
fix: Correct missing None default value for spec condition_type

### DIFF
--- a/nisystemlink/clients/spec/models/_condition.py
+++ b/nisystemlink/clients/spec/models/_condition.py
@@ -31,7 +31,7 @@ class ConditionRange(JsonModel):
 class ConditionValueBase(JsonModel):
     """The base type for conditions that can be represented in several styles."""
 
-    condition_type: Optional[ConditionType]
+    condition_type: Optional[ConditionType] = None
     """Type of the Condition."""
 
 

--- a/tests/integration/notebook/test_notebook_client.py
+++ b/tests/integration/notebook/test_notebook_client.py
@@ -566,7 +566,6 @@ class TestNotebookClient:
         with pytest.raises(ApiException, match="Not Found"):
             client.get_execution_by_id(id="InvalidExecutionId")
 
-    @pytest.mark.focus
     @responses.activate
     def test__filter_executions_by_status__returns_executions_matches_status(
         self,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a missing None default value to the optional condition_type, which is required for Pydantic v2 type validation.

### Why should this Pull Request be merged?

The Pydantic v2 update missed a late arriving model change that is breaking validation in the integration tests.

### What testing has been done?

Integration tests are all passing locally
