### PR TITLE
feat: Spec client | Add Get Spec API 

### DIFF
--- a/docs/api_reference/spec.rst
+++ b/docs/api_reference/spec.rst
@@ -12,6 +12,7 @@ nisystemlink.clients.spec
    .. automethod:: delete_specs
    .. automethod:: query_specs
    .. automethod:: update_specs
+   .. automethod:: get_spec
 
 .. automodule:: nisystemlink.clients.spec.models
    :members:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -162,7 +162,7 @@ When constructing a :class:`.SpecClient`, you can pass an
 :class:`.HttpConfigurationManager`), or let :class:`.SpecClient` use the
 default connection. The default connection depends on your environment.
 
-With a :class:`.SpecClient` object, you can: 
+With a :class:`.SpecClient` object, you can:
 
 * Create and delete specifications under a product.
 
@@ -170,12 +170,14 @@ With a :class:`.SpecClient` object, you can:
 
 * Query for specifications on any fields using DynamicLinq syntax.
 
+* Get a specification using an Id.
+
 Examples
 ~~~~~~~~
 
-Create and Query Specifications
+Create, Get and Query Specifications
 
-.. literalinclude:: ../examples/spec/query_specs.py
+.. literalinclude:: ../examples/spec/get_and_query_specs.py
    :language: python
    :linenos:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -162,7 +162,7 @@ When constructing a :class:`.SpecClient`, you can pass an
 :class:`.HttpConfigurationManager`), or let :class:`.SpecClient` use the
 default connection. The default connection depends on your environment.
 
-With a :class:`.SpecClient` object, you can:
+With a :class:`.SpecClient` object, you can: 
 
 * Create and delete specifications under a product.
 

--- a/examples/spec/get_and_query_specs.py
+++ b/examples/spec/get_and_query_specs.py
@@ -68,7 +68,11 @@ spec_requests = [
 ]
 
 # Create the specs on the server
-client.create_specs(CreateSpecificationsRequest(specs=spec_requests))
+created_response = client.create_specs(CreateSpecificationsRequest(specs=spec_requests))
+
+# use get for first spec created
+if len(created_response.created_specs) > 0:
+    created_spec = client.get_spec(created_response.created_specs[0].id)
 
 # You can query specs based on any field using DynamicLinq syntax.
 # These are just some representative examples.

--- a/examples/spec/get_and_query_specs.py
+++ b/examples/spec/get_and_query_specs.py
@@ -71,7 +71,7 @@ spec_requests = [
 created_response = client.create_specs(CreateSpecificationsRequest(specs=spec_requests))
 
 # use get for first spec created
-if len(created_response.created_specs) > 0:
+if created_response.created_specs and len(created_response.created_specs) > 0:
     created_spec = client.get_spec(created_response.created_specs[0].id)
 
 # You can query specs based on any field using DynamicLinq syntax.

--- a/nisystemlink/clients/core/_api_error_response.py
+++ b/nisystemlink/clients/core/_api_error_response.py
@@ -1,7 +1,8 @@
 from nisystemlink.clients.core._api_error import ApiError
+from nisystemlink.clients.core._uplink._json_model import JsonModel
 
 
-class ApiErrorResponse:
+class ApiErrorResponse(JsonModel):
     """Represents an error response from the SystemLink API responses."""
 
     error: ApiError

--- a/nisystemlink/clients/core/_api_error_response.py
+++ b/nisystemlink/clients/core/_api_error_response.py
@@ -1,8 +1,0 @@
-from nisystemlink.clients.core._api_error import ApiError
-from nisystemlink.clients.core._uplink._json_model import JsonModel
-
-
-class ApiErrorResponse(JsonModel):
-    """Represents an error response from the SystemLink APIs."""
-
-    error: ApiError

--- a/nisystemlink/clients/core/_api_error_response.py
+++ b/nisystemlink/clients/core/_api_error_response.py
@@ -5,4 +5,3 @@ class ApiErrorResponse:
     """Represents an error response from the SystemLink API responses."""
 
     error: ApiError
-

--- a/nisystemlink/clients/core/_api_error_response.py
+++ b/nisystemlink/clients/core/_api_error_response.py
@@ -3,6 +3,6 @@ from nisystemlink.clients.core._uplink._json_model import JsonModel
 
 
 class ApiErrorResponse(JsonModel):
-    """Represents an error response from the SystemLink API responses."""
+    """Represents an error response from the SystemLink APIs."""
 
     error: ApiError

--- a/nisystemlink/clients/core/_api_error_response.py
+++ b/nisystemlink/clients/core/_api_error_response.py
@@ -1,0 +1,8 @@
+from nisystemlink.clients.core._api_error import ApiError
+
+
+class ApiErrorResponse:
+    """Represents an error response from the SystemLink API responses."""
+
+    error: ApiError
+

--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -3,6 +3,7 @@
 from typing import List, Optional
 
 from nisystemlink.clients import core
+from nisystemlink.clients.core._api_error_response import ApiErrorResponse
 from nisystemlink.clients.core._uplink._base_client import BaseClient
 from nisystemlink.clients.core._uplink._methods import get, post
 from uplink import Field, retry
@@ -97,7 +98,7 @@ class SpecClient(BaseClient):
         ...
 
     @get("specs/{id}")
-    def get_spec(self, id: str) -> models.Specification:
+    def get_spec(self, id: str) -> models.Specification | ApiErrorResponse:
         """Retrieves a single spec by id.
 
         Args:

--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -1,6 +1,6 @@
 """Implementation of SpecClient"""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from nisystemlink.clients import core
 from nisystemlink.clients.core._api_error_response import ApiErrorResponse
@@ -98,7 +98,7 @@ class SpecClient(BaseClient):
         ...
 
     @get("specs/{id}")
-    def get_spec(self, id: str) -> models.Specification | ApiErrorResponse:
+    def get_spec(self, id: str) -> Union[models.Specification, ApiErrorResponse]:
         """Retrieves a single spec by id.
 
         Args:

--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -1,9 +1,8 @@
 """Implementation of SpecClient"""
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from nisystemlink.clients import core
-from nisystemlink.clients.core._api_error_response import ApiErrorResponse
 from nisystemlink.clients.core._uplink._base_client import BaseClient
 from nisystemlink.clients.core._uplink._methods import get, post
 from uplink import Field, retry
@@ -98,7 +97,7 @@ class SpecClient(BaseClient):
         ...
 
     @get("specs/{id}")
-    def get_spec(self, id: str) -> Union[models.Specification, ApiErrorResponse]:
+    def get_spec(self, id: str) -> models.Specification:
         """Retrieves a single spec by id.
 
         Args:

--- a/nisystemlink/clients/spec/_spec_client.py
+++ b/nisystemlink/clients/spec/_spec_client.py
@@ -96,6 +96,22 @@ class SpecClient(BaseClient):
         """
         ...
 
+    @get("specs/{id}")
+    def get_spec(self, id: str) -> models.Specification:
+        """Retrieves a single spec by id.
+
+        Args:
+            id (str): Unique ID of a specification.
+
+        Returns:
+            The single spec matching `id`
+
+        Raises:
+            ApiException: if unable to communicate with the `nispec` service or if there are invalid
+            arguments.
+        """
+        ...
+
     @post("update-specs")
     def update_specs(
         self, specs: models.UpdateSpecificationsRequest

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -2,6 +2,7 @@ import uuid
 from typing import List
 
 import pytest
+from nisystemlink.clients.core._api_exception import ApiException
 from nisystemlink.clients.core._http_configuration import HttpConfiguration
 from nisystemlink.clients.spec import SpecClient
 from nisystemlink.clients.spec.models import (
@@ -261,6 +262,14 @@ class TestSpec:
         assert get_spec_response is not None
         assert get_spec_response.id == created_spec.id
         assert get_spec_response.product_id == productId
+
+    def test__get_non_existant_spec_by_id__get_spec_fails(self, client: SpecClient):
+        non_existant_spec_id = "10"
+
+        with pytest.raises(ApiException) as exception_info:
+            client.get_spec(non_existant_spec_id)
+
+        assert exception_info.value.http_status_code == 404
 
     def test__query_product__all_returned(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -237,6 +237,28 @@ class TestSpec:
         updated_spec = update_response.updated_specs[0]
         assert updated_spec.version == 1
 
+    def test__get_spec_by_id__spec_matches_expected(
+        self, client: SpecClient, create_specs, product
+    ):
+        productId = product
+        spec = CreateSpecificationsRequestObject(
+            product_id=productId,
+            spec_id="spec1",
+            type=SpecificationType.FUNCTIONAL,
+            keywords=["work", "reviewed"],
+            category="Parametric Specs",
+            block="newBlock",
+        )
+        response = create_specs(CreateSpecificationsRequest(specs=[spec]))
+        assert response is not None
+        assert len(response.created_specs) == 1
+        created_spec = response.created_specs[0]
+
+        get_spec_response = client.get_spec(created_spec.id)
+        assert get_spec_response is not None
+        assert get_spec_response.id == created_spec.id
+        assert get_spec_response.product_id == productId
+
     def test__query_product__all_returned(
         self, client: SpecClient, create_specs, create_specs_for_query, product
     ):

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -2,6 +2,7 @@ import uuid
 from typing import List
 
 import pytest
+from nisystemlink.clients.core._api_exception import ApiException
 from nisystemlink.clients.core._http_configuration import HttpConfiguration
 from nisystemlink.clients.spec import SpecClient
 from nisystemlink.clients.spec.models import (
@@ -21,6 +22,7 @@ from nisystemlink.clients.spec.models import (
     UpdateSpecificationsRequest,
     UpdateSpecificationsRequestObject,
 )
+from nisystemlink.clients.spec.models._specification import Specification
 
 
 @pytest.fixture(scope="class")
@@ -255,9 +257,25 @@ class TestSpec:
         created_spec = response.created_specs[0]
 
         get_spec_response = client.get_spec(created_spec.id)
-        assert get_spec_response is not None
-        assert get_spec_response.id == created_spec.id
-        assert get_spec_response.product_id == productId
+        if isinstance(get_spec_response, Specification):
+            assert get_spec_response.id == created_spec.id
+            assert get_spec_response.product_id == productId
+
+    def test__get_non_existant_spec_by_id__get_spec_fails(
+        self, client: SpecClient
+    ):
+        non_existant_spec_id = "10"
+        with pytest.raises(ApiException) as exception_info:
+            client.get_spec(non_existant_spec_id)
+        assert exception_info.value.http_status_code == 404
+
+    def test__get_spec_by_invalid_id__get_spec_fails(
+        self, client: SpecClient
+    ):
+        invalid_spec_id = "110ac9e841879870a0b410dabfa02a0e"
+        with pytest.raises(ApiException) as exception_info:
+            client.get_spec(invalid_spec_id)
+        assert exception_info.value.http_status_code == 400
 
     def test__query_product__all_returned(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -2,7 +2,6 @@ import uuid
 from typing import List
 
 import pytest
-from nisystemlink.clients.core._api_exception import ApiException
 from nisystemlink.clients.core._http_configuration import HttpConfiguration
 from nisystemlink.clients.spec import SpecClient
 from nisystemlink.clients.spec.models import (
@@ -22,7 +21,6 @@ from nisystemlink.clients.spec.models import (
     UpdateSpecificationsRequest,
     UpdateSpecificationsRequestObject,
 )
-from nisystemlink.clients.spec.models._specification import Specification
 
 
 @pytest.fixture(scope="class")
@@ -260,25 +258,9 @@ class TestSpec:
 
         get_spec_response = client.get_spec(created_spec.id)
 
-        assert isinstance(get_spec_response, Specification)
+        assert get_spec_response is not None
         assert get_spec_response.id == created_spec.id
         assert get_spec_response.product_id == productId
-
-    def test__get_non_existant_spec_by_id__get_spec_fails(self, client: SpecClient):
-        non_existant_spec_id = "10"
-
-        with pytest.raises(ApiException) as exception_info:
-            client.get_spec(non_existant_spec_id)
-
-        assert exception_info.value.http_status_code == 404
-
-    def test__get_spec_by_invalid_id__get_spec_fails(self, client: SpecClient):
-        invalid_spec_id = "110ac9e841879870a0b410dabfa02a0e"
-
-        with pytest.raises(ApiException) as exception_info:
-            client.get_spec(invalid_spec_id)
-
-        assert exception_info.value.http_status_code == 400
 
     def test__query_product__all_returned(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -251,26 +251,33 @@ class TestSpec:
             category="Parametric Specs",
             block="newBlock",
         )
+
         response = create_specs(CreateSpecificationsRequest(specs=[spec]))
+
         assert response is not None
         assert len(response.created_specs) == 1
         created_spec = response.created_specs[0]
 
         get_spec_response = client.get_spec(created_spec.id)
+
         assert isinstance(get_spec_response, Specification)
         assert get_spec_response.id == created_spec.id
         assert get_spec_response.product_id == productId
 
     def test__get_non_existant_spec_by_id__get_spec_fails(self, client: SpecClient):
         non_existant_spec_id = "10"
+
         with pytest.raises(ApiException) as exception_info:
             client.get_spec(non_existant_spec_id)
+
         assert exception_info.value.http_status_code == 404
 
     def test__get_spec_by_invalid_id__get_spec_fails(self, client: SpecClient):
         invalid_spec_id = "110ac9e841879870a0b410dabfa02a0e"
+
         with pytest.raises(ApiException) as exception_info:
             client.get_spec(invalid_spec_id)
+
         assert exception_info.value.http_status_code == 400
 
     def test__query_product__all_returned(

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -257,9 +257,9 @@ class TestSpec:
         created_spec = response.created_specs[0]
 
         get_spec_response = client.get_spec(created_spec.id)
-        if isinstance(get_spec_response, Specification):
-            assert get_spec_response.id == created_spec.id
-            assert get_spec_response.product_id == productId
+        assert isinstance(get_spec_response, Specification)
+        assert get_spec_response.id == created_spec.id
+        assert get_spec_response.product_id == productId
 
     def test__get_non_existant_spec_by_id__get_spec_fails(self, client: SpecClient):
         non_existant_spec_id = "10"

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -261,17 +261,13 @@ class TestSpec:
             assert get_spec_response.id == created_spec.id
             assert get_spec_response.product_id == productId
 
-    def test__get_non_existant_spec_by_id__get_spec_fails(
-        self, client: SpecClient
-    ):
+    def test__get_non_existant_spec_by_id__get_spec_fails(self, client: SpecClient):
         non_existant_spec_id = "10"
         with pytest.raises(ApiException) as exception_info:
             client.get_spec(non_existant_spec_id)
         assert exception_info.value.http_status_code == 404
 
-    def test__get_spec_by_invalid_id__get_spec_fails(
-        self, client: SpecClient
-    ):
+    def test__get_spec_by_invalid_id__get_spec_fails(self, client: SpecClient):
         invalid_spec_id = "110ac9e841879870a0b410dabfa02a0e"
         with pytest.raises(ApiException) as exception_info:
             client.get_spec(invalid_spec_id)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds the `Get spec` API of the `Specification management service` to the spec client module.

### Why should this Pull Request be merged?

It is helpful for users to retrieve a specification directly by its ID, rather than using the query API to fetch a single specification.

### What testing has been done?

Automated integration tests are included.

API link: [Swagger link](https://dev-api.lifecyclesolutions.ni.com/niapis/?urls.primaryName=Specification+Management#/Specifications/get_nispec_v1_specs__id_)