### PR TITLE
chore: Clean up table left behind by DFS test

### DIFF
--- a/tests/integration/dataframe/test_dataframe.py
+++ b/tests/integration/dataframe/test_dataframe.py
@@ -275,8 +275,10 @@ class TestDataFrame:
         for table in client.list_tables(id=ids).tables:
             assert table.properties == {"pig": "oink"}
 
-    def test__modify_tables__returns_partial_success(self, client: DataFrameClient):
-        id = client.create_table(basic_table_model)
+    def test__modify_tables__returns_partial_success(
+        self, client: DataFrameClient, create_table
+    ):
+        id = create_table(basic_table_model)
 
         updates = [
             TableMetadataModification(id=id, name="Modified table")


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Ensures data tables created by DFS integration tests are deleted at the end of the test.

### Why should this Pull Request be merged?

One data table is currently getting left behind when running the DFS tests. It has a name of "Modified table".

### What testing has been done?

Ran the tests locally against a locally running DFS. Verified no tables are left behind anymore.
