### PR TITLE
Allow username/password connection for base client.

### DIFF
--- a/nisystemlink/clients/core/_uplink/_base_client.py
+++ b/nisystemlink/clients/core/_uplink/_base_client.py
@@ -104,6 +104,7 @@ class BaseClient(Consumer):
             converter=_JsonModelConverter(),
             hooks=[_handle_http_status],
             client=session,
+            auth=(configuration.username, configuration.password),
         )
         if configuration.api_keys:
             self.session.headers.update(configuration.api_keys)


### PR DESCRIPTION
This allows FileClient to be used with a username password auth setup.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

See title

### Why should this Pull Request be merged?

See title

### What testing has been done?

Tested on local server.
