### PR TITLE
chore: Bump version from 2.18.0 to 2.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nisystemlink-clients"
-version = "2.18.0"
+version = "2.18.1"
 description = "NI-SystemLink Python API"
 authors = ["National Instruments"]
 maintainers = [


### PR DESCRIPTION
Manually bump version due to tag typo in previous commit

- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bumps the version after ##157

### Why should this Pull Request be merged?

To release the package with the new version

### What testing has been done?

Relying on PR build
