### PR TITLE
fix: Revert #158

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nisystemlink-clients"
-version = "2.18.1"
+version = "2.18.0"
 description = "NI-SystemLink Python API"
 authors = ["National Instruments"]
 maintainers = [


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reverts #158 and lets semantic-release publish as normal

### Why should this Pull Request be merged?

The current state will not release via semantic-release, it returns an error when the current package version mismatches with the pyproject.toml version.

Instead marking this as fix lets semantic-release release as normal.

### What testing has been done?

Relying on PR
