### PR TITLE
fix: Alarm Client Severity Level Documentation Changes

### DIFF
--- a/nisystemlink/clients/alarm/models/_alarm.py
+++ b/nisystemlink/clients/alarm/models/_alarm.py
@@ -57,7 +57,7 @@ class AlarmTransition(JsonModel):
     Valid values for CLEAR transitions are [-1, -1].
     Valid values for SET transitions are [1, 2147483647].
     Note that the SystemLink Alarm UI only has display strings for SET severities in the range [1, 4].
-    The AlarmSeverityLevel enum provides values for standard severity levels.
+    The :class:`AlarmSeverityLevel` enum provides values for standard severity levels.
     """
 
     value: str

--- a/nisystemlink/clients/alarm/models/_create_or_update_alarm_request.py
+++ b/nisystemlink/clients/alarm/models/_create_or_update_alarm_request.py
@@ -22,7 +22,7 @@ class CreateAlarmTransition(JsonModel):
     Valid values for CLEAR transitions are [-1, -1].
     Valid values for SET transitions are [1, 2147483647].
     Note that the SystemLink Alarm UI only has display strings for SET severities in the range [1, 4].
-    The AlarmSeverityLevel enum provides values for standard severity levels.
+    The :class:`AlarmSeverityLevel` enum provides values for standard severity levels.
     """
 
     value: str | None = None


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR includes documentation changes in the alarm client severity level attribute. Added `:class:` to specify the `AlarmSeverityLevel` as a class reference in the documentation.

### Why should this Pull Request be merged?

Once this PR is merged, `AlarmSeverityLevel` in the `severity_level` attribute's documentation will be referenced by the respective class.

### What testing has been done?

Manual testing has been done.
