### PR TITLE
[Files] Transform string into part for metadata in upload_files request

### DIFF
--- a/nisystemlink/clients/file/_file_client.py
+++ b/nisystemlink/clients/file/_file_client.py
@@ -292,7 +292,9 @@ class FileClient(BaseClient):
 
         Args:
             file: The file to upload.
-            metadata: PART Dictionary with key/value pairs
+            metadata: Multipart part for file metadata, typically ``None`` or a
+                ``(None, json_string, "application/json")`` tuple where
+                ``json_string`` contains the metadata key/value pairs.
             id: Specify an unique (among all file) 24-digit Hex string ID of the file once it is uploaded.
                 Defaults to None.
             workspace: The id of the workspace the file belongs to. Defaults to None.

--- a/nisystemlink/clients/file/_file_client.py
+++ b/nisystemlink/clients/file/_file_client.py
@@ -327,13 +327,13 @@ class FileClient(BaseClient):
             ApiException: if unable to communicate with the File Service.
         """
         if metadata:
-            metadata_str = json.dumps(metadata)
+            metadata_part = (None, json.dumps(metadata), "application/json")
         else:
-            metadata_str = None
+            metadata_part = None
 
         file_id = self.__upload_file(
             file=file,
-            metadata=metadata_str,
+            metadata=metadata_part,
             id=id,
             workspace=workspace,
         )

--- a/nisystemlink/clients/file/_file_client.py
+++ b/nisystemlink/clients/file/_file_client.py
@@ -292,7 +292,7 @@ class FileClient(BaseClient):
 
         Args:
             file: The file to upload.
-            metadata: JSON Dictionary with key/value pairs
+            metadata: PART Dictionary with key/value pairs
             id: Specify an unique (among all file) 24-digit Hex string ID of the file once it is uploaded.
                 Defaults to None.
             workspace: The id of the workspace the file belongs to. Defaults to None.

--- a/tests/integration/file/test_file_client.py
+++ b/tests/integration/file/test_file_client.py
@@ -44,7 +44,9 @@ def test_file(client: FileClient):
     """Fixture to return a factory that uploads a file."""
     file_ids = []
 
-    def _test_file(file_name: str = TEST_FILE_NAME, cleanup: bool = True, metadata: dict = None) -> str:
+    def _test_file(
+        file_name: str = TEST_FILE_NAME, cleanup: bool = True, metadata: dict = None
+    ) -> str:
         test_file = io.BytesIO(TEST_FILE_DATA)
         test_file.name = file_name
         file_id = client.upload_file(file=test_file, metadata=metadata)
@@ -92,7 +94,10 @@ class TestFileClient:
         assert len(api_info.model_dump()) != 0
 
     def test__upload_file_with_metadata__succeeds(
-        self, client: FileClient, binary_file_data: BinaryIO, random_filename_extension: str
+        self,
+        client: FileClient,
+        binary_file_data: BinaryIO,
+        random_filename_extension: str,
     ):
         file_name = random_filename_extension
         metadata = {"CustomProp": "CustomValue"}

--- a/tests/integration/file/test_file_client.py
+++ b/tests/integration/file/test_file_client.py
@@ -45,7 +45,7 @@ def test_file(client: FileClient):
     file_ids = []
 
     def _test_file(
-        file_name: str = TEST_FILE_NAME, cleanup: bool = True, metadata: dict = None
+        file_name: str = TEST_FILE_NAME, cleanup: bool = True, metadata: dict = {}
     ) -> str:
         test_file = io.BytesIO(TEST_FILE_DATA)
         test_file.name = file_name

--- a/tests/integration/file/test_file_client.py
+++ b/tests/integration/file/test_file_client.py
@@ -33,7 +33,7 @@ def client(enterprise_config) -> FileClient:
     return FileClient(enterprise_config)
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def binary_file_data() -> BinaryIO:
     """Test Binary file content."""
     return io.BytesIO(TEST_FILE_DATA)
@@ -44,10 +44,10 @@ def test_file(client: FileClient):
     """Fixture to return a factory that uploads a file."""
     file_ids = []
 
-    def _test_file(file_name: str = TEST_FILE_NAME, cleanup: bool = True) -> str:
+    def _test_file(file_name: str = TEST_FILE_NAME, cleanup: bool = True, metadata: dict = None) -> str:
         test_file = io.BytesIO(TEST_FILE_DATA)
         test_file.name = file_name
-        file_id = client.upload_file(file=test_file)
+        file_id = client.upload_file(file=test_file, metadata=metadata)
 
         if cleanup:
             file_ids.append(file_id)
@@ -97,8 +97,7 @@ class TestFileClient:
         file_name = random_filename_extension
         metadata = {"CustomProp": "CustomValue"}
 
-        # Upload the file with metadata
-        file_id = client.upload_file(file=binary_file_data, metadata=metadata)
+        file_id = test_file(file_name=file_name, metadata=metadata)
 
         # Verify the file was created with correct metadata
         files = client.get_files(ids=[file_id])
@@ -110,12 +109,6 @@ class TestFileClient:
         assert (
             len(files.available_files[0].properties.keys()) == len(metadata) + 1
         )  # Name + 1 custom property
-
-        client.delete_file(id=file_id)
-
-        # confirm that file was deleted
-        files = client.get_files(ids=[file_id])
-        assert files.total_count == 0
 
     def test__upload_get_delete_files__succeeds(
         self, client: FileClient, test_file, random_filename_extension
@@ -130,12 +123,6 @@ class TestFileClient:
         assert files.available_files[0].id == file_id
         assert files.available_files[0].properties is not None
         assert files.available_files[0].properties["Name"] == random_filename_extension
-
-        client.delete_file(id=file_id)
-
-        # confirm that file was deleted
-        files = client.get_files(ids=[file_id])
-        assert files.total_count == 0
 
     def test__delete_file__invalid_id_raises(
         self, client: FileClient, invalid_file_id: str

--- a/tests/integration/file/test_file_client.py
+++ b/tests/integration/file/test_file_client.py
@@ -91,6 +91,32 @@ class TestFileClient:
         api_info = client.api_info()
         assert len(api_info.model_dump()) != 0
 
+    def test__upload_file_with_metadata__succeeds(
+        self, client: FileClient, binary_file_data: BinaryIO, random_filename_extension: str
+    ):
+        file_name = random_filename_extension
+        metadata = {"CustomProp": "CustomValue"}
+
+        # Upload the file with metadata
+        file_id = client.upload_file(file=binary_file_data, metadata=metadata)
+
+        # Verify the file was created with correct metadata
+        files = client.get_files(ids=[file_id])
+        assert files.total_count == 1
+        assert len(files.available_files) == 1
+        assert files.available_files[0].id == file_id
+        assert files.available_files[0].properties is not None
+        assert files.available_files[0].properties["Name"] == file_name
+        assert (
+            len(files.available_files[0].properties.keys()) == len(metadata) + 1
+        )  # Name + 1 custom property
+
+        client.delete_file(id=file_id)
+
+        # confirm that file was deleted
+        files = client.get_files(ids=[file_id])
+        assert files.total_count == 0
+
     def test__upload_get_delete_files__succeeds(
         self, client: FileClient, test_file, random_filename_extension
     ):

--- a/tests/integration/file/test_file_client.py
+++ b/tests/integration/file/test_file_client.py
@@ -96,7 +96,7 @@ class TestFileClient:
     def test__upload_file_with_metadata__succeeds(
         self,
         client: FileClient,
-        binary_file_data: BinaryIO,
+        test_file,
         random_filename_extension: str,
     ):
         file_name = random_filename_extension


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix `upload_files` method to accept metadata field with custom data.

### Why should this Pull Request be merged?

This fixes a bug issued here #206

### What testing has been done?

Testing done using the script provided in the issue
