### PR TITLE
Add explicit service package exports

### DIFF
--- a/nisystemlink/clients/alarm/__init__.py
+++ b/nisystemlink/clients/alarm/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with AlarmClient for alarm management."""
+
 from nisystemlink.clients.alarm._alarm_client import AlarmClient
 
-# flake8: noqa
+__all__ = ["AlarmClient"]

--- a/nisystemlink/clients/artifact/__init__.py
+++ b/nisystemlink/clients/artifact/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with ArtifactClient for artifact management."""
+
 from ._artifact_client import ArtifactClient
 
-# flake8: noqa
+__all__ = ["ArtifactClient"]

--- a/nisystemlink/clients/assetmanagement/__init__.py
+++ b/nisystemlink/clients/assetmanagement/__init__.py
@@ -1,5 +1,7 @@
+"""Start here with AssetManagementClient for asset management."""
+
 from nisystemlink.clients.assetmanagement._asset_management_client import (
     AssetManagementClient,
 )
 
-# flake8: noqa
+__all__ = ["AssetManagementClient"]

--- a/nisystemlink/clients/dataframe/__init__.py
+++ b/nisystemlink/clients/dataframe/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with DataFrameClient for dataframe operations."""
+
 from ._data_frame_client import DataFrameClient
 
-# flake8: noqa
+__all__ = ["DataFrameClient"]

--- a/nisystemlink/clients/feeds/__init__.py
+++ b/nisystemlink/clients/feeds/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with FeedsClient for feed management."""
+
 from ._feeds_client import FeedsClient
 
-# flake8: noqa
+__all__ = ["FeedsClient"]

--- a/nisystemlink/clients/file/__init__.py
+++ b/nisystemlink/clients/file/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with FileClient for file operations."""
+
 from ._file_client import FileClient
 
-# flake8: noqa
+__all__ = ["FileClient"]

--- a/nisystemlink/clients/notebook/__init__.py
+++ b/nisystemlink/clients/notebook/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with NotebookClient for notebook management."""
+
 from ._notebook_client import NotebookClient
 
-# flake8: noqa
+__all__ = ["NotebookClient"]

--- a/nisystemlink/clients/notification/__init__.py
+++ b/nisystemlink/clients/notification/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with NotificationClient for notification management."""
+
 from ._notification_client import NotificationClient
 
-# flake8: noqa
+__all__ = ["NotificationClient"]

--- a/nisystemlink/clients/product/__init__.py
+++ b/nisystemlink/clients/product/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with ProductClient for product management."""
+
 from ._product_client import ProductClient
 
-# flake8: noqa
+__all__ = ["ProductClient"]

--- a/nisystemlink/clients/spec/__init__.py
+++ b/nisystemlink/clients/spec/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with SpecClient for specification management."""
+
 from ._spec_client import SpecClient
 
-# flake8: noqa
+__all__ = ["SpecClient"]

--- a/nisystemlink/clients/systems/__init__.py
+++ b/nisystemlink/clients/systems/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with SystemsClient for system management."""
+
 from nisystemlink.clients.systems._systems_client import SystemsClient
 
-# flake8: noqa
+__all__ = ["SystemsClient"]

--- a/nisystemlink/clients/tag/__init__.py
+++ b/nisystemlink/clients/tag/__init__.py
@@ -6,7 +6,9 @@ from ._data_type import DataType
 from ._retention_type import RetentionType
 from ._tag_data import TagData
 from ._tag_with_aggregates import TagWithAggregates  # noqa: I100
-from ._async_tag_query_result_collection import AsyncTagQueryResultCollection  # noqa: I100
+from ._async_tag_query_result_collection import (
+    AsyncTagQueryResultCollection,
+)  # noqa: I100
 from ._itag_reader import ITagReader
 from ._itag_writer import ITagWriter
 from ._buffered_tag_writer import BufferedTagWriter  # noqa: I100

--- a/nisystemlink/clients/tag/__init__.py
+++ b/nisystemlink/clients/tag/__init__.py
@@ -2,23 +2,23 @@
 
 """Start here with TagManager for tag operations and helper types."""
 
-from ._async_tag_query_result_collection import AsyncTagQueryResultCollection
-from ._buffered_tag_writer import BufferedTagWriter
 from ._data_type import DataType
-from ._itag_reader import ITagReader
-from ._itag_writer import ITagWriter
 from ._retention_type import RetentionType
 from ._tag_data import TagData
-from ._tag_data_update import TagDataUpdate
-from ._tag_manager import TagManager
-from ._tag_path_utilities import TagPathUtilities
-from ._tag_query_result_collection import TagQueryResultCollection
-from ._tag_selection import TagSelection
-from ._tag_subscription import TagSubscription
-from ._tag_update_fields import TagUpdateFields
+from ._tag_with_aggregates import TagWithAggregates  # noqa: I100
+from ._async_tag_query_result_collection import AsyncTagQueryResultCollection  # noqa: I100
+from ._itag_reader import ITagReader
+from ._itag_writer import ITagWriter
+from ._buffered_tag_writer import BufferedTagWriter  # noqa: I100
 from ._tag_value_reader import TagValueReader
 from ._tag_value_writer import TagValueWriter
-from ._tag_with_aggregates import TagWithAggregates
+from ._tag_update_fields import TagUpdateFields  # noqa: I100
+from ._tag_data_update import TagDataUpdate  # noqa: I100
+from ._tag_path_utilities import TagPathUtilities
+from ._tag_query_result_collection import TagQueryResultCollection
+from ._tag_subscription import TagSubscription
+from ._tag_selection import TagSelection  # noqa: I100
+from ._tag_manager import TagManager  # noqa: I100
 
 __all__ = [
     "DataType",

--- a/nisystemlink/clients/tag/__init__.py
+++ b/nisystemlink/clients/tag/__init__.py
@@ -1,21 +1,41 @@
 # -*- coding: utf-8 -*-
 
-from ._data_type import DataType
-from ._retention_type import RetentionType
-from ._tag_data import TagData
-from ._tag_with_aggregates import TagWithAggregates
+"""Start here with TagManager for tag operations and helper types."""
+
 from ._async_tag_query_result_collection import AsyncTagQueryResultCollection
+from ._buffered_tag_writer import BufferedTagWriter
+from ._data_type import DataType
 from ._itag_reader import ITagReader
 from ._itag_writer import ITagWriter
-from ._buffered_tag_writer import BufferedTagWriter
-from ._tag_value_reader import TagValueReader
-from ._tag_value_writer import TagValueWriter
-from ._tag_update_fields import TagUpdateFields
+from ._retention_type import RetentionType
+from ._tag_data import TagData
 from ._tag_data_update import TagDataUpdate
+from ._tag_manager import TagManager
 from ._tag_path_utilities import TagPathUtilities
 from ._tag_query_result_collection import TagQueryResultCollection
-from ._tag_subscription import TagSubscription
 from ._tag_selection import TagSelection
-from ._tag_manager import TagManager
+from ._tag_subscription import TagSubscription
+from ._tag_update_fields import TagUpdateFields
+from ._tag_value_reader import TagValueReader
+from ._tag_value_writer import TagValueWriter
+from ._tag_with_aggregates import TagWithAggregates
 
-# flake8: noqa
+__all__ = [
+    "DataType",
+    "RetentionType",
+    "TagData",
+    "TagWithAggregates",
+    "AsyncTagQueryResultCollection",
+    "ITagReader",
+    "ITagWriter",
+    "BufferedTagWriter",
+    "TagValueReader",
+    "TagValueWriter",
+    "TagUpdateFields",
+    "TagDataUpdate",
+    "TagPathUtilities",
+    "TagQueryResultCollection",
+    "TagSubscription",
+    "TagSelection",
+    "TagManager",
+]

--- a/nisystemlink/clients/tag/__init__.py
+++ b/nisystemlink/clients/tag/__init__.py
@@ -6,9 +6,9 @@ from ._data_type import DataType
 from ._retention_type import RetentionType
 from ._tag_data import TagData
 from ._tag_with_aggregates import TagWithAggregates  # noqa: I100
-from ._async_tag_query_result_collection import (
+from ._async_tag_query_result_collection import (  # noqa: I100
     AsyncTagQueryResultCollection,
-)  # noqa: I100
+)
 from ._itag_reader import ITagReader
 from ._itag_writer import ITagWriter
 from ._buffered_tag_writer import BufferedTagWriter  # noqa: I100

--- a/nisystemlink/clients/test_plan/__init__.py
+++ b/nisystemlink/clients/test_plan/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with TestPlanClient for test plan management."""
+
 from ._test_plan_client import TestPlanClient
 
-# flake8: noqa
+__all__ = ["TestPlanClient"]

--- a/nisystemlink/clients/testmonitor/__init__.py
+++ b/nisystemlink/clients/testmonitor/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with TestMonitorClient for test monitor operations."""
+
 from ._test_monitor_client import TestMonitorClient
 
-# flake8: noqa
+__all__ = ["TestMonitorClient"]

--- a/nisystemlink/clients/work_item/__init__.py
+++ b/nisystemlink/clients/work_item/__init__.py
@@ -1,3 +1,5 @@
+"""Start here with WorkItemClient for work item operations."""
+
 from ._work_item_client import WorkItemClient, WorkItemExecuteApiException
 
-# flake8: noqa
+__all__ = ["WorkItemClient", "WorkItemExecuteApiException"]

--- a/tests/test_service_package_exports.py
+++ b/tests/test_service_package_exports.py
@@ -1,0 +1,72 @@
+"""Validate the public surface declared by each service package."""
+
+import ast
+import unittest
+from pathlib import Path
+
+PACKAGE_EXPORTS = {
+    "alarm": ["AlarmClient"],
+    "artifact": ["ArtifactClient"],
+    "assetmanagement": ["AssetManagementClient"],
+    "dataframe": ["DataFrameClient"],
+    "feeds": ["FeedsClient"],
+    "file": ["FileClient"],
+    "notebook": ["NotebookClient"],
+    "notification": ["NotificationClient"],
+    "product": ["ProductClient"],
+    "spec": ["SpecClient"],
+    "systems": ["SystemsClient"],
+    "tag": [
+        "DataType",
+        "RetentionType",
+        "TagData",
+        "TagWithAggregates",
+        "AsyncTagQueryResultCollection",
+        "ITagReader",
+        "ITagWriter",
+        "BufferedTagWriter",
+        "TagValueReader",
+        "TagValueWriter",
+        "TagUpdateFields",
+        "TagDataUpdate",
+        "TagPathUtilities",
+        "TagQueryResultCollection",
+        "TagSubscription",
+        "TagSelection",
+        "TagManager",
+    ],
+    "test_plan": ["TestPlanClient"],
+    "testmonitor": ["TestMonitorClient"],
+    "work_item": ["WorkItemClient", "WorkItemExecuteApiException"],
+}
+
+
+class TestServicePackageExports(unittest.TestCase):
+    """Verify service package docstrings and explicit export lists."""
+
+    def test_service_package_exports_are_explicit(self):
+        """Each service package should document and declare its public exports."""
+        package_root = Path(__file__).resolve().parents[1] / "nisystemlink" / "clients"
+
+        for package_name, exported_names in PACKAGE_EXPORTS.items():
+            with self.subTest(package_name=package_name):
+                module_path = package_root / package_name / "__init__.py"
+                module = ast.parse(module_path.read_text(encoding="utf-8"))
+                imported_names = []
+                declared_exports = None
+                module_docstring = ast.get_docstring(module)
+
+                self.assertIsNotNone(module_docstring)
+                assert module_docstring is not None
+                self.assertTrue(module_docstring.startswith("Start here with "))
+
+                for node in module.body:
+                    if isinstance(node, ast.ImportFrom):
+                        imported_names.extend(alias.name for alias in node.names)
+                    elif isinstance(node, ast.Assign):
+                        for target in node.targets:
+                            if isinstance(target, ast.Name) and target.id == "__all__":
+                                declared_exports = ast.literal_eval(node.value)
+
+                self.assertEqual(declared_exports, exported_names)
+                self.assertCountEqual(imported_names, exported_names)

--- a/tests/test_service_package_exports.py
+++ b/tests/test_service_package_exports.py
@@ -57,7 +57,8 @@ class TestServicePackageExports(unittest.TestCase):
                 module_docstring = ast.get_docstring(module)
 
                 self.assertIsNotNone(module_docstring)
-                assert module_docstring is not None
+                if module_docstring is None:
+                    self.fail(f"Missing module docstring in {module_path}")
                 self.assertTrue(module_docstring.startswith("Start here with "))
 
                 for node in module.body:


### PR DESCRIPTION
## Summary
- add short "Start here" package docstrings that point readers to the primary service client or tag entry point
- replace blanket `# flake8: noqa` package exports with explicit `__all__` declarations across service packages
- add a regression test that verifies each service package documents and declares its public exports

## Why This Helps
- it turns the package surface into an explicit contract instead of leaving it implicit in import side effects or wildcard exports
- it gives IDEs, static analysis, and coding agents a reliable list of supported imports, which reduces guesswork about whether a symbol is public or internal
- the new "Start here" docstrings give both humans and agents a canonical entry point, which makes generated examples and import suggestions more likely to use the intended top-level client
- the export test keeps that contract from drifting, so future refactors are less likely to break discoverability or accidentally hide supported symbols

## Validation
- `poetry run poe check`
- `poetry run poe lint`
- `poetry run poe types`
- `poetry run poe test`

## Notes
- `nisystemlink.clients.tag` keeps a few narrow `# noqa: I100` import-order suppressions because its runtime-safe import order is intentionally different from alphabetical order; the touched tag import path is covered by tests
