### PR TITLE
Bump python-semantic-release and support release from minor and patch branches

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build-lint-unit-test, integration-test]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' &&
+        (
+          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
+          (
+            startsWith(github.ref, 'refs/heads/') &&
+            endsWith(github.ref, '.x')
+          )
+        )
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,9 +2,9 @@ name: Python package
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, '*.x']
   pull_request:
-    branches: [master, main]
+    branches: [master, main, '*.x']
 
 jobs:
   build-lint-unit-test:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,6 +77,12 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "action@github.com"
           semantic-release version
+        env:
+          # To generate a new token use the following guide, providing access to the "repo" scope.
+          # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+          # Once you update the secret on the repo, ensure you update the master/main protected branch policy
+          # to allow your user permission to "bypass required pull requests".
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
       - name: Publish package distributions to PyPI using Twine
         if: steps.release.outputs.released == 'true'
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,10 +71,23 @@ jobs:
           cache: "poetry"
       - run: poetry install
       - name: Semantic release
+        id: release
         run: |
-          pip install python-semantic-release==7.34.6
+          pip install python-semantic-release==10.6.1
           git config --global user.name "github-actions"
           git config --global user.email "action@github.com"
+          semantic-release version
+      - name: Publish package distributions to PyPI using Twine
+        if: steps.release.outputs.released == 'true'
+        run: |
+          pip install twine==6.1.0
+          python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
+          TWINE_PASSWORD: ${{secrets.PYPI_PASSWORD}}
+      - name: Publish package distributions to GitHub Releases
+        if: steps.release.outputs.released == 'true'
+        run: |
           semantic-release publish
         env:
           # To generate a new token use the following guide, providing access to the "repo" scope.
@@ -82,5 +95,3 @@ jobs:
           # Once you update the secret on the repo, ensure you update the master/main protected branch policy
           # to allow your user permission to "bypass required pull requests".
           GH_TOKEN: ${{secrets.GH_TOKEN}}
-          REPOSITORY_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
-          REPOSITORY_PASSWORD: ${{secrets.PYPI_PASSWORD}}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,15 +49,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build-lint-unit-test, integration-test]
-    if: github.event_name == 'push' &&
+    if: >
+      github.event_name == 'push' &&
+      (
+        github.ref == 'refs/heads/master' ||
+        github.ref == 'refs/heads/main' ||
         (
-          github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/main' ||
-          (
-            startsWith(github.ref, 'refs/heads/') &&
-            endsWith(github.ref, '.x')
-          )
+          startsWith(github.ref, 'refs/heads/') &&
+          endsWith(github.ref, '.x')
         )
+      )
     steps:
       - uses: actions/checkout@v3
         with:
@@ -71,7 +72,6 @@ jobs:
           cache: "poetry"
       - run: poetry install
       - name: Semantic release
-        id: release
         run: |
           pip install python-semantic-release==10.6.1
           git config --global user.name "github-actions"
@@ -82,17 +82,19 @@ jobs:
           # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
           # Once you update the secret on the repo, ensure you update the master/main protected branch policy
           # to allow your user permission to "bypass required pull requests".
-          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          GH_TOKEN: ${{secrets.GH_TOKEN}}     
       - name: Publish package distributions to PyPI using Twine
-        if: steps.release.outputs.released == 'true'
+        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.
+        if: hashFiles('dist/*') != ''
         run: |
           pip install twine==6.1.0
           python -m twine upload dist/*
         env:
           TWINE_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
           TWINE_PASSWORD: ${{secrets.PYPI_PASSWORD}}
-      - name: Publish package distributions to GitHub Releases
-        if: steps.release.outputs.released == 'true'
+      - name: Semantic release - Publish package distributions to GitHub Releases
+        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.      
+        if: hashFiles('dist/*') != ''
         run: |
           semantic-release publish
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -82,7 +82,7 @@ jobs:
           # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
           # Once you update the secret on the repo, ensure you update the master/main protected branch policy
           # to allow your user permission to "bypass required pull requests".
-          GH_TOKEN: ${{secrets.GH_TOKEN}}     
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
       - name: Publish package distributions to PyPI using Twine
         # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.
         if: hashFiles('dist/*') != ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions to *nisystemlink-clients-python* are welcome from all!
 the canonical upstream repository hosted on
 [GitHub](https://github.com/ni/nisystemlink-clients-python/).
 
-*nisystemlink-clients-python* follows a pull-request model for development.  If
+*nisystemlink-clients-python* follows ax ypull-request model for development.  If
 you wish to contribute, you will need to create a GitHub account, fork this
 project, push a branch with your changes to your project, and then submit a
 pull request.
@@ -33,6 +33,28 @@ To contribute to this project, it is recommended that you follow these steps:
 5. Run all the unit tests again (which include the tests you just added),
    and confirm that they all pass.
 6. Send a GitHub Pull Request to the main repository's master branch. GitHub
+   Pull Requests are the expected method of code collaboration on this project.
+
+## Patching older versions
+1. Contact the [repository owners](https://github.com/AlexDanDuna/nisystemlink-clients-python/blob/master/.github/CODEOWNERS) for approval and ask them to create a
+   branch based on the commit that was used to generate the release to be patched.
+   The naming for this branch should follow this guideline:
+   - "1.x", if we want to create a new minor version for version 1
+   - "1.3.x", if we want to create a new patch version for version 1.3
+
+2. Fork the repository on GitHub.
+3. Create and switch to a branch based on the commit that
+   was used to generate the release that you want to patch.
+4. Run the unit tests on your system (see Testing section). At this point,
+   if any tests fail, do not begin development. Try to investigate these
+   failures. If you're unable to do so, report an issue through our
+   [GitHub issues page](https://github.com/ni/nisystemlink-clients-python/issues).
+5. Write new tests that demonstrate your bug or feature. Ensure that these
+   new tests fail.
+6. Make your change.
+7. Run all the unit tests again (which include the tests you just added),
+   and confirm that they all pass.
+8. Send a GitHub Pull Request to the main repository branch that was created as a result of step 1. GitHub
    Pull Requests are the expected method of code collaboration on this project.
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions to *nisystemlink-clients-python* are welcome from all!
 the canonical upstream repository hosted on
 [GitHub](https://github.com/ni/nisystemlink-clients-python/).
 
-*nisystemlink-clients-python* follows ax ypull-request model for development.  If
+*nisystemlink-clients-python* follows a pull-request model for development.  If
 you wish to contribute, you will need to create a GitHub account, fork this
 project, push a branch with your changes to your project, and then submit a
 pull request.
@@ -36,7 +36,7 @@ To contribute to this project, it is recommended that you follow these steps:
    Pull Requests are the expected method of code collaboration on this project.
 
 ## Patching older versions
-1. Contact the [repository owners](https://github.com/AlexDanDuna/nisystemlink-clients-python/blob/master/.github/CODEOWNERS) for approval and ask them to create a
+1. Contact the [repository owners](https://github.com/ni/nisystemlink-clients-python/blob/master/.github/CODEOWNERS) for approval and ask them to create a
    branch based on the commit that was used to generate the release to be patched.
    The naming for this branch should follow this guideline:
    - "1.x", if we want to create a new minor version for version 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ To contribute to this project, it is recommended that you follow these steps:
    - "1.3.x", if we want to create a new patch version for version 1.3
 
 2. Fork the repository on GitHub.
-3. Create and switch to a branch based on the commit that
-   was used to generate the release that you want to patch.
+3. Fetch and check out the maintenance branch created in step 1, then create and
+   switch to a working branch from it.
 4. Run the unit tests on your system (see Testing section). At this point,
    if any tests fail, do not begin development. Try to investigate these
    failures. If you're unable to do so, report an issue through our

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,16 @@ markers = [
 exclude = ".*\\.pyi"
 
 [tool.semantic_release]
-# Allow releasing from master and branches of the form "1.x", "1.2.x", etc.
-branch        = "^(master|\\d+(?:\\.\\d+)*\\.x)$"
 version_toml  = ["pyproject.toml:tool.poetry.version"]
 build_command = "poetry build"
 
+# Allow releasing from the `master` branch.
+[tool.semantic_release.branches.master]
+match = "^master$"
+
+# Allow releasing from maintenance branches named "1.x", "1.2.x", etc.
+[tool.semantic_release.branches.maintenance]
+match = "^\\d+(?:\\.\\d+)*\\.x$"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,8 @@ markers = [
 exclude = ".*\\.pyi"
 
 [tool.semantic_release]
-branch        = "master"
+# Allow releasing from master and branches of the form "1.x", "1.2.x", etc.
+branch        = "^(master|\\d+(?:\\.\\d+)*\\.x)$"
 version_toml  = ["pyproject.toml:tool.poetry.version"]
 build_command = "poetry build"
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow releasing new minor and patch versions from branches following the format `1.x' and '1.2.x':
- The GitHub Action was modified to trigger on pushes and PRs targetting "*.x" branches
- In order to allow for matching such branches for Python Semantic Release, it was required to bump `python-semantic-release` version as v7 (which was used previously) did not allow for regex in the branch name. I bumped the version to the latest v10.6.1, given the fact that v10 and v9 did not really introduce breaking changes, and upgrading to v8 would require adaptations anyway:
    - the toml configuration for python-semantic-release to match the new branch configuration format of python semantic release, as indicated [here](https://github.com/python-semantic-release/python-semantic-release/blob/v10.6.1/docs/upgrading/08-upgrade.rst#multibranch-releases) and [here](https://github.com/python-semantic-release/python-semantic-release/blob/v10.6.1/docs/concepts/multibranch_releases.rst)
    - `semantic-release publish` no longer creates the GitHub release, nor publishes to PyPi. According to the docs (see [here](https://github.com/python-semantic-release/python-semantic-release/blob/v10.6.1/docs/upgrading/08-upgrade.rst#repurposing-of-version-and-publish-commands) and [here](https://github.com/python-semantic-release/python-semantic-release/blob/v10.6.1/docs/upgrading/08-upgrade.rst#python-semantic-release-github-action)), this now has to be replaced by running `semantic-release version` (which builds the packages, creates the GH release, and the tag), publishing the package to the GH release by running `semantic-release publish`, and publishing the package to PyPi (I used twine for this).


### Why should this Pull Request be merged?

To ease the  release of patched versions in the future. The implementation is generic and supports all branches that have a version, ending in ".x", as their names.

### What testing has been done?

I tested the modifications on my own fork, with my own PyPi account:
- verified that the pipeline triggers work on the patch branches
- verified that the pipeline successfully publishes a GH Release and a PyPi release, when run on the patch branches