### PR TITLE
chore: Fix workflows, update codeowners, and cherry-pick 95f67b5 - Bump python-semantic-release and support release from minor and patch branches (#218)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mure @spanglerco @cameronwaterman
+* @rbell517 @spanglerco @cameronwaterman

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
       - run: poetry run poe types
   release:
     runs-on: ubuntu-latest
-    needs: [build-lint-unit-test, integration-test]
+    needs: [build]
     if: >
       github.event_name == 'push' &&
       (

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,9 +2,9 @@ name: Python package
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, '*.x']
   pull_request:
-    branches: [master, main]
+    branches: [master, main, '*.x']
 
 jobs:
   build:
@@ -30,8 +30,17 @@ jobs:
       - run: poetry run poe types
   release:
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    needs: [build-lint-unit-test, integration-test]
+    if: >
+      github.event_name == 'push' &&
+      (
+        github.ref == 'refs/heads/master' ||
+        github.ref == 'refs/heads/main' ||
+        (
+          startsWith(github.ref, 'refs/heads/') &&
+          endsWith(github.ref, '.x')
+        )
+      )
     steps:
       - uses: actions/checkout@v3
         with:
@@ -46,9 +55,29 @@ jobs:
       - run: poetry install
       - name: Semantic release
         run: |
-          pip install python-semantic-release==7.34.6
+          pip install python-semantic-release==10.6.1
           git config --global user.name "github-actions"
           git config --global user.email "action@github.com"
+          semantic-release version
+        env:
+          # To generate a new token use the following guide, providing access to the "repo" scope.
+          # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+          # Once you update the secret on the repo, ensure you update the master/main protected branch policy
+          # to allow your user permission to "bypass required pull requests".
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
+      - name: Publish package distributions to PyPI using Twine
+        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.
+        if: hashFiles('dist/*') != ''
+        run: |
+          pip install twine==6.1.0
+          python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
+          TWINE_PASSWORD: ${{secrets.PYPI_PASSWORD}}
+      - name: Semantic release - Publish package distributions to GitHub Releases
+        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.      
+        if: hashFiles('dist/*') != ''
+        run: |
           semantic-release publish
         env:
           # To generate a new token use the following guide, providing access to the "repo" scope.
@@ -56,5 +85,3 @@ jobs:
           # Once you update the secret on the repo, ensure you update the master/main protected branch policy
           # to allow your user permission to "bypass required pull requests".
           GH_TOKEN: ${{secrets.GH_TOKEN}}
-          REPOSITORY_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
-          REPOSITORY_PASSWORD: ${{secrets.PYPI_PASSWORD}}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,28 @@ To contribute to this project, it is recommended that you follow these steps:
 6. Send a GitHub Pull Request to the main repository's master branch. GitHub
    Pull Requests are the expected method of code collaboration on this project.
 
+## Patching older versions
+1. Contact the [repository owners](https://github.com/ni/nisystemlink-clients-python/blob/master/.github/CODEOWNERS) for approval and ask them to create a
+   branch based on the commit that was used to generate the release to be patched.
+   The naming for this branch should follow this guideline:
+   - "1.x", if we want to create a new minor version for version 1
+   - "1.3.x", if we want to create a new patch version for version 1.3
+
+2. Fork the repository on GitHub.
+3. Fetch and check out the maintenance branch created in step 1, then create and
+   switch to a working branch from it.
+4. Run the unit tests on your system (see Testing section). At this point,
+   if any tests fail, do not begin development. Try to investigate these
+   failures. If you're unable to do so, report an issue through our
+   [GitHub issues page](https://github.com/ni/nisystemlink-clients-python/issues).
+5. Write new tests that demonstrate your bug or feature. Ensure that these
+   new tests fail.
+6. Make your change.
+7. Run all the unit tests again (which include the tests you just added),
+   and confirm that they all pass.
+8. Send a GitHub Pull Request to the main repository branch that was created as a result of step 1. GitHub
+   Pull Requests are the expected method of code collaboration on this project.
+
 ## Testing
 
 Before running any tests, you must have a supported version of Python (3.8+) and [Poetry](https://python-poetry.org/docs/) installed locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ To contribute to this project, it is recommended that you follow these steps:
    Pull Requests are the expected method of code collaboration on this project.
 
 ## Patching older versions
-1. Contact the [repository owners](https://github.com/ni/nisystemlink-clients-python/blob/master/.github/CODEOWNERS) for approval and ask them to create a
+1. Contact the [repository owners](/.github/CODEOWNERS) for approval and ask them to create a
    branch based on the commit that was used to generate the release to be patched.
    The naming for this branch should follow this guideline:
    - "1.x", if we want to create a new minor version for version 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,17 @@ markers = [
 exclude = ".*\\.pyi"
 
 [tool.semantic_release]
-branch        = "master"
 version_toml  = ["pyproject.toml:tool.poetry.version"]
 build_command = "poetry build"
+
+# Allow releasing from the `master` branch.
+[tool.semantic_release.branches.master]
+match = "^master$"
+
+# Allow releasing from maintenance branches named "1.x", "1.2.x", etc.
+[tool.semantic_release.branches.maintenance]
+match = "^\\d+(?:\\.\\d+)*\\.x$"
+
 
 [build-system]
 requires      = ["poetry-core"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Cherry pick https://github.com/ni/nisystemlink-clients-python/commit/95f67b56d4bf8de56e3fe0eaa2d8e2f19005c237.
- Update CODEOWNERS to current ones
- Update Python and Ubuntu in .readthedocs.yaml so that the readthedocs workflow works again
- Pin `poetry` to 1.8.5 (last version to support Py3.8 officially) in the repo workflow, as installing the latest was leading to errors when `poetry install`-ing on Python 3.8.

### Why should this Pull Request be merged?

Add support for releasing out of maintenance branches, such as the current one - "1.6.x".

### What testing has been done?

Testing was done for the PR that was merged in the master branch.
