### PR TITLE
chore: Do not forbid extra fields in Pydantic models to fix incosistency between models and current SLE APIs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,9 +83,3 @@ def enterprise_config(pytestconfig):
         return core.HttpConfiguration(uri, api_key)
     else:
         pytest.skip("--enterprise-uri or --enterprise-api-key setting not found")
-
-
-@pytest.fixture(scope="session", autouse=True)
-def pydantic_forbid_extra_fields():
-    """Fixture to disable allowing extra fields in our Pydantic models."""
-    JsonModel.Config.extra = Extra.forbid


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Two tests for the File and Spec clients are failing, since api info now returns operations that are not properly modeled in their Operations:
Log of failed workflow step:
[6_Run poetry run pytest --cloud-api-key  --enterprise-uri https_test-api.lifecyclesolutions.ni.com --enterprise-api-key .txt](https://github.com/user-attachments/files/30055909/6_Run.poetry.run.pytest.--cloud-api-key.--enterprise-uri.https_test-api.lifecyclesolutions.ni.com.--enterprise-api-key.txt)

Skip forbidding extra fields in conftest.py to get the tests to run. Thanks to @spanglerco for suggesting the fix.

### Why should this Pull Request be merged?

We're aiming to release a patch for SLS from this branch; enforcing that the models match the current SLE APIs, in this old library  version, is out of scope.

### What testing has been done?

Pipeline passes