### PR TITLE
fix: Set SystemLink Server certificate path in JupyterHttpConfiguration, on Windows

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,9 +83,3 @@ def enterprise_config(pytestconfig):
         return core.HttpConfiguration(uri, api_key)
     else:
         pytest.skip("--enterprise-uri or --enterprise-api-key setting not found")
-
-
-@pytest.fixture(scope="session", autouse=True)
-def pydantic_forbid_extra_fields():
-    """Fixture to disable allowing extra fields in our Pydantic models."""
-    JsonModel.Config.extra = Extra.forbid

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 from nisystemlink.clients import core
+from nisystemlink.clients.core._internal._path_constants import PathConstants
 
 
 class JupyterHttpConfiguration(core.HttpConfiguration):
@@ -14,8 +15,10 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
     _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
     _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
     _SYSTEMLINK_SERVER_CERT_PATH = (
-        r"C:\ProgramData\National Instruments\Skyline"
-        r"\Certificates\http-server\http-server.cer"
+        PathConstants.application_data_directory
+        / "Certificates"
+        / "http-server"
+        / "http-server.cer"
     )
 
     def __init__(self) -> None:
@@ -29,7 +32,7 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
 
         # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder
-        # is no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config
+        #  is no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config
         # files under `HttpConfigurations` are no longer readable, creating client objects from this library, from SLS
         # notebooks, will default to using this `JupyterHttpConfiguration`. However, this does not set a `cert_path`,
         # so HTTPS requests will fail.
@@ -41,12 +44,8 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         if sys.platform.startswith("win") and os.path.exists(
             self._SYSTEMLINK_SERVER_CERT_PATH
         ):
-            import pathlib
-
             super().__init__(
-                http_uri,
-                api_key,
-                cert_path=pathlib.Path(self._SYSTEMLINK_SERVER_CERT_PATH),
+                http_uri, api_key, cert_path=self._SYSTEMLINK_SERVER_CERT_PATH
             )
         else:
             super().__init__(http_uri, api_key)

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -26,9 +26,9 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
 
         # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder is
-        # no longer granted for scripts running under the Jupyter/NotebookExecution services. Since config files under
-        # HttpConfigurations are no longer readable, creating client objects from this library, from SLS notebooks,
-        # will default to using this JupyterHttpConfiguration. However, this does not set a `cert_path`, so HTTPS
+        # no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config files under
+        # `HttpConfigurations` are no longer readable, creating client objects from this library, from SLS notebooks,
+        # will default to using this `JupyterHttpConfiguration`. However, this does not set a `cert_path`, so HTTPS
         # requests will fail.
         # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the 
         # `cert_path`, if the file exists. This will allow clients created with the default configuration to use this CA certificate.

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -3,6 +3,7 @@
 """Implementation of JupyterHttpConfiguration."""
 
 import os
+import sys
 
 from nisystemlink.clients import core
 
@@ -12,6 +13,7 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
 
     _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
     _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
+    _SYSTEMLINK_SERVER_CERT_PATH = r"C:\ProgramData\National Instruments\Skyline\Certificates\http-server\http-server.cer"
 
     def __init__(self) -> None:
         """Initialize a configuration for SystemLink using API key-based
@@ -20,6 +22,12 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         Raises:
             KeyError: if the expected environment variables are not set.
         """
-        super().__init__(
-            os.environ[self._HTTP_URI_ENV_VAR], os.environ[self._HTTP_API_KEY_ENV_VAR]
-        )
+        http_uri = os.environ[self._HTTP_URI_ENV_VAR]
+        api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
+
+        if sys.platform.startswith("win"):
+            super().__init__(
+                http_uri, api_key, cert_path=self._SYSTEMLINK_SERVER_CERT_PATH
+            )
+        else:
+            super().__init__(http_uri, api_key)

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -26,7 +26,9 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
         systemlink_server_cert_path = (
             PathConstants.application_data_directory
-            / "Certificates" / "http-server" / "http-server.cer"
+            / "Certificates"
+            / "http-server"
+            / "http-server.cer"
         )
 
         # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder
@@ -39,9 +41,9 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         # to use this CA certificate.
         # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid
         # `cert_path` will lead to errors.
-        if sys.platform.startswith("win") and os.path.exists(systemlink_server_cert_path):
-            super().__init__(
-                http_uri, api_key, cert_path=systemlink_server_cert_path
-            )
+        if sys.platform.startswith("win") and os.path.exists(
+            systemlink_server_cert_path
+        ):
+            super().__init__(http_uri, api_key, cert_path=systemlink_server_cert_path)
         else:
             super().__init__(http_uri, api_key)

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -25,8 +25,13 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         http_uri = os.environ[self._HTTP_URI_ENV_VAR]
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
 
-        # When running SystemLink Server notebooks (Windows), pass Web Server CA certificate's path as the `cert_path`,
-        # if the file exists. This will allow clients created with the default configuration to use this CA certificate.
+        # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder is
+        # no longer granted for scripts running under the Jupyter/NotebookExecution services. Since config files under
+        # HttpConfigurations are no longer readable, creating client objects from this library, from SLS notebooks,
+        # will default to using this JupyterHttpConfiguration. However, this does not set a `cert_path`, so HTTPS
+        # requests will fail.
+        # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the 
+        # `cert_path`, if the file exists. This will allow clients created with the default configuration to use this CA certificate.
         # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid `cert_path`
         # will lead to errors.
         if sys.platform.startswith("win") and os.path.exists(

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -25,7 +25,13 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         http_uri = os.environ[self._HTTP_URI_ENV_VAR]
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
 
-        if sys.platform.startswith("win"):
+        # When running SystemLink Server notebooks (Windows), pass Web Server CA certificate's path as the `cert_path`,
+        # if the file exists. This will allow clients created with the default configuration to use this CA certificate.
+        # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid `cert_path`
+        # will lead to errors.
+        if sys.platform.startswith("win") and os.path.exists(
+            self._SYSTEMLINK_SERVER_CERT_PATH
+        ):
             super().__init__(
                 http_uri, api_key, cert_path=self._SYSTEMLINK_SERVER_CERT_PATH
             )

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -13,7 +13,10 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
 
     _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
     _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
-    _SYSTEMLINK_SERVER_CERT_PATH = r"C:\ProgramData\National Instruments\Skyline\Certificates\http-server\http-server.cer"
+    _SYSTEMLINK_SERVER_CERT_PATH = (
+        r"C:\ProgramData\National Instruments\Skyline"
+        r"\Certificates\http-server\http-server.cer"
+    )
 
     def __init__(self) -> None:
         """Initialize a configuration for SystemLink using API key-based
@@ -25,15 +28,16 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         http_uri = os.environ[self._HTTP_URI_ENV_VAR]
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
 
-        # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder is
-        # no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config files under
-        # `HttpConfigurations` are no longer readable, creating client objects from this library, from SLS notebooks,
-        # will default to using this `JupyterHttpConfiguration`. However, this does not set a `cert_path`, so HTTPS
-        # requests will fail.
-        # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the
-        # `cert_path`, if the file exists. This will allow clients created with the default configuration to use this CA certificate.
-        # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid `cert_path`
-        # will lead to errors.
+        # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder
+        # is no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config
+        # files under `HttpConfigurations` are no longer readable, creating client objects from this library, from SLS
+        # notebooks, will default to using this `JupyterHttpConfiguration`. However, this does not set a `cert_path`,
+        # so HTTPS requests will fail.
+        # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's
+        # path as the `cert_path`, if the file exists. This will allow clients created with the default configuration
+        # to use this CA certificate.
+        # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid
+        # `cert_path` will lead to errors.
         if sys.platform.startswith("win") and os.path.exists(
             self._SYSTEMLINK_SERVER_CERT_PATH
         ):

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -41,8 +41,12 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         if sys.platform.startswith("win") and os.path.exists(
             self._SYSTEMLINK_SERVER_CERT_PATH
         ):
+            import pathlib
+
             super().__init__(
-                http_uri, api_key, cert_path=self._SYSTEMLINK_SERVER_CERT_PATH
+                http_uri,
+                api_key,
+                cert_path=pathlib.Path(self._SYSTEMLINK_SERVER_CERT_PATH),
             )
         else:
             super().__init__(http_uri, api_key)

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -30,7 +30,7 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         # `HttpConfigurations` are no longer readable, creating client objects from this library, from SLS notebooks,
         # will default to using this `JupyterHttpConfiguration`. However, this does not set a `cert_path`, so HTTPS
         # requests will fail.
-        # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the 
+        # When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the
         # `cert_path`, if the file exists. This will allow clients created with the default configuration to use this CA certificate.
         # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid `cert_path`
         # will lead to errors.

--- a/nisystemlink/clients/core/_jupyter_http_configuration.py
+++ b/nisystemlink/clients/core/_jupyter_http_configuration.py
@@ -14,12 +14,6 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
 
     _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
     _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
-    _SYSTEMLINK_SERVER_CERT_PATH = (
-        PathConstants.application_data_directory
-        / "Certificates"
-        / "http-server"
-        / "http-server.cer"
-    )
 
     def __init__(self) -> None:
         """Initialize a configuration for SystemLink using API key-based
@@ -30,6 +24,10 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         """
         http_uri = os.environ[self._HTTP_URI_ENV_VAR]
         api_key = os.environ[self._HTTP_API_KEY_ENV_VAR]
+        systemlink_server_cert_path = (
+            PathConstants.application_data_directory
+            / "Certificates" / "http-server" / "http-server.cer"
+        )
 
         # SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder
         #  is no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config
@@ -41,11 +39,9 @@ class JupyterHttpConfiguration(core.HttpConfiguration):
         # to use this CA certificate.
         # If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid
         # `cert_path` will lead to errors.
-        if sys.platform.startswith("win") and os.path.exists(
-            self._SYSTEMLINK_SERVER_CERT_PATH
-        ):
+        if sys.platform.startswith("win") and os.path.exists(systemlink_server_cert_path):
             super().__init__(
-                http_uri, api_key, cert_path=self._SYSTEMLINK_SERVER_CERT_PATH
+                http_uri, api_key, cert_path=systemlink_server_cert_path
             )
         else:
             super().__init__(http_uri, api_key)

--- a/tests/core/test_jupyter_http_configuration.py
+++ b/tests/core/test_jupyter_http_configuration.py
@@ -17,6 +17,12 @@ _SYSTEMLINK_API_KEY_HEADER = "x-ni-api-key"
 
 
 class TestJupyterHttpConfiguration:
+    # Patch PathConstants._application_data_directory so that we have the proper Windows path
+    # when running the tests on Linux.
+    @patch(
+        "nisystemlink.clients.core._internal._path_constants.PathConstants._application_data_directory",
+        pathlib.Path(r"C:\ProgramData\National Instruments\Skyline"),
+    )
     def test__cert_file_exists_on_windows__cert_path_is_passed(self):
         def mock_exists(path):
             if path == _SYSTEMLINK_SERVER_CERT_PATH:

--- a/tests/core/test_jupyter_http_configuration.py
+++ b/tests/core/test_jupyter_http_configuration.py
@@ -43,6 +43,12 @@ class TestJupyterHttpConfiguration:
                     assert config.api_keys[_SYSTEMLINK_API_KEY_HEADER] == "my-api-key"
                     assert config.cert_path == _SYSTEMLINK_SERVER_CERT_PATH
 
+    # Patch PathConstants._application_data_directory so that we have the proper Windows path
+    # when running the tests on Linux.
+    @patch(
+        "nisystemlink.clients.core._internal._path_constants.PathConstants._application_data_directory",
+        pathlib.Path(r"C:\ProgramData\National Instruments\Skyline"),
+    )
     def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
         def mock_exists(path):
             if path == _SYSTEMLINK_SERVER_CERT_PATH:

--- a/tests/core/test_jupyter_http_configuration.py
+++ b/tests/core/test_jupyter_http_configuration.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 from unittest.mock import patch
 
 from nisystemlink.clients.core import JupyterHttpConfiguration
@@ -6,17 +7,19 @@ from nisystemlink.clients.core import JupyterHttpConfiguration
 
 _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
 _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
-_SYSTEMLINK_SERVER_CERTIFICATE_PATH = (
-    r"C:\ProgramData\National Instruments\Skyline"
-    r"\Certificates\http-server\http-server.cer"
+_SYSTEMLINK_SERVER_CERT_PATH = (
+    pathlib.Path(r"C:\ProgramData\National Instruments\Skyline")
+    / "Certificates"
+    / "http-server"
+    / "http-server.cer"
 )
-_SYSTEM_LINK_API_KEY_HEADER = "x-ni-api-key"
+_SYSTEMLINK_API_KEY_HEADER = "x-ni-api-key"
 
 
 class TestJupyterHttpConfiguration:
     def test__cert_file_exists_on_windows__cert_path_is_passed(self):
         def mock_exists(path):
-            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+            if path == _SYSTEMLINK_SERVER_CERT_PATH:
                 return True
             return False
 
@@ -31,12 +34,12 @@ class TestJupyterHttpConfiguration:
                 ):
                     config = JupyterHttpConfiguration()
                     assert config.server_uri == "https://my-uri"
-                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
-                    assert config.cert_path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH
+                    assert config.api_keys[_SYSTEMLINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path == _SYSTEMLINK_SERVER_CERT_PATH
 
     def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
         def mock_exists(path):
-            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+            if path == _SYSTEMLINK_SERVER_CERT_PATH:
                 return False
             return True
 
@@ -51,12 +54,12 @@ class TestJupyterHttpConfiguration:
                 ):
                     config = JupyterHttpConfiguration()
                     assert config.server_uri == "https://my-uri"
-                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.api_keys[_SYSTEMLINK_API_KEY_HEADER] == "my-api-key"
                     assert config.cert_path is None
 
     def test__cert_file_exists_on_linux__cert_path_is_not_passed(self):
         def mock_exists(path):
-            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+            if path == _SYSTEMLINK_SERVER_CERT_PATH:
                 return True
             return False
 
@@ -71,12 +74,12 @@ class TestJupyterHttpConfiguration:
                 ):
                     config = JupyterHttpConfiguration()
                     assert config.server_uri == "https://my-uri"
-                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.api_keys[_SYSTEMLINK_API_KEY_HEADER] == "my-api-key"
                     assert config.cert_path is None
 
     def test__cert_file_does_not_exist_on_linux__cert_path_is_not_passed(self):
         def mock_exists(path):
-            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+            if path == _SYSTEMLINK_SERVER_CERT_PATH:
                 return False
             return True
 
@@ -91,5 +94,5 @@ class TestJupyterHttpConfiguration:
                 ):
                     config = JupyterHttpConfiguration()
                     assert config.server_uri == "https://my-uri"
-                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.api_keys[_SYSTEMLINK_API_KEY_HEADER] == "my-api-key"
                     assert config.cert_path is None

--- a/tests/core/test_jupyter_http_configuration.py
+++ b/tests/core/test_jupyter_http_configuration.py
@@ -1,0 +1,111 @@
+from nisystemlink.clients.core import JupyterHttpConfiguration
+
+from unittest.mock import patch
+import os
+
+_HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
+_HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
+_SYSTEMLINK_SERVER_CERTIFICATE_PATH = r"C:\ProgramData\National Instruments\Skyline\Certificates\http-server\http-server.cer"
+_SYSTEM_LINK_API_KEY_HEADER = "x-ni-api-key"
+
+
+class TestJupyterHttpConfiguration:
+    def test__cert_file_exists_on_windows__cert_path_is_passed(self):
+        def mock_exists(path):
+            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+                return True
+            return False
+
+        with patch("sys.platform", "win32"):
+            with patch("os.path.exists", side_effect=mock_exists):
+                with patch.dict(
+                    os.environ,
+                    {
+                        _HTTP_URI_ENV_VAR: "https://my-uri",
+                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
+                    },
+                ):
+                    config = JupyterHttpConfiguration()
+                    assert config.server_uri == "https://my-uri"
+                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH
+
+    def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
+        def mock_exists(path):
+            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+                return False
+            return True
+
+        with patch("sys.platform", "win32"):
+            with patch("os.path.exists", side_effect=mock_exists):
+                with patch.dict(
+                    os.environ,
+                    {
+                        _HTTP_URI_ENV_VAR: "https://my-uri",
+                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
+                    },
+                ):
+                    config = JupyterHttpConfiguration()
+                    assert config.server_uri == "https://my-uri"
+                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path is None
+
+    def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
+        def mock_exists(path):
+            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+                return False
+            return True
+
+        with patch("sys.platform", "win32"):
+            with patch("os.path.exists", side_effect=mock_exists):
+                with patch.dict(
+                    os.environ,
+                    {
+                        _HTTP_URI_ENV_VAR: "https://my-uri",
+                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
+                    },
+                ):
+                    config = JupyterHttpConfiguration()
+                    assert config.server_uri == "https://my-uri"
+                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path is None
+
+    def test__cert_file_exists_on_linux__cert_path_is_not_passed(self):
+        def mock_exists(path):
+            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+                return True
+            return False
+
+        with patch("sys.platform", "linux"):
+            with patch("os.path.exists", side_effect=mock_exists):
+                with patch.dict(
+                    os.environ,
+                    {
+                        _HTTP_URI_ENV_VAR: "https://my-uri",
+                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
+                    },
+                ):
+                    config = JupyterHttpConfiguration()
+                    assert config.server_uri == "https://my-uri"
+                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path is None
+
+    def test__cert_file_does_not_exist_on_linux__cert_path_is_not_passed(self):
+        def mock_exists(path):
+            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
+                return False
+            return True
+
+        with patch("sys.platform", "linux"):
+            with patch("os.path.exists", side_effect=mock_exists):
+                with patch.dict(
+                    os.environ,
+                    {
+                        _HTTP_URI_ENV_VAR: "https://my-uri",
+                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
+                    },
+                ):
+                    config = JupyterHttpConfiguration()
+                    assert config.server_uri == "https://my-uri"
+                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
+                    assert config.cert_path is None

--- a/tests/core/test_jupyter_http_configuration.py
+++ b/tests/core/test_jupyter_http_configuration.py
@@ -1,11 +1,15 @@
+import os
+from unittest.mock import patch
+
 from nisystemlink.clients.core import JupyterHttpConfiguration
 
-from unittest.mock import patch
-import os
 
 _HTTP_URI_ENV_VAR = "SYSTEMLINK_HTTP_URI"
 _HTTP_API_KEY_ENV_VAR = "SYSTEMLINK_API_KEY"
-_SYSTEMLINK_SERVER_CERTIFICATE_PATH = r"C:\ProgramData\National Instruments\Skyline\Certificates\http-server\http-server.cer"
+_SYSTEMLINK_SERVER_CERTIFICATE_PATH = (
+    r"C:\ProgramData\National Instruments\Skyline"
+    r"\Certificates\http-server\http-server.cer"
+)
 _SYSTEM_LINK_API_KEY_HEADER = "x-ni-api-key"
 
 
@@ -29,26 +33,6 @@ class TestJupyterHttpConfiguration:
                     assert config.server_uri == "https://my-uri"
                     assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
                     assert config.cert_path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH
-
-    def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
-        def mock_exists(path):
-            if path == _SYSTEMLINK_SERVER_CERTIFICATE_PATH:
-                return False
-            return True
-
-        with patch("sys.platform", "win32"):
-            with patch("os.path.exists", side_effect=mock_exists):
-                with patch.dict(
-                    os.environ,
-                    {
-                        _HTTP_URI_ENV_VAR: "https://my-uri",
-                        _HTTP_API_KEY_ENV_VAR: "my-api-key",
-                    },
-                ):
-                    config = JupyterHttpConfiguration()
-                    assert config.server_uri == "https://my-uri"
-                    assert config.api_keys[_SYSTEM_LINK_API_KEY_HEADER] == "my-api-key"
-                    assert config.cert_path is None
 
     def test__cert_file_does_not_exist_on_windows__cert_path_is_not_passed(self):
         def mock_exists(path):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

SystemLink Server 26Q3 restricts notebook executions (by default). Access to the `HttpConfigurations` folder is
no longer granted for notebooks running under the JupyterHub/NotebookExecution services. Since config files under
`HttpConfigurations` are no longer readable, creating client objects from this library, from SLS notebooks,
will default to using `JupyterHttpConfiguration`. However, this does not set a `cert_path`, so HTTPS
requests will fail.

When running SystemLink Server notebooks (Windows), we will therefore pass the Web Server CA certificate's path as the 
`cert_path`, if the file exists. This will allow clients created with the default configuration to use this CA certificate.
If the file does not exist (when the Web Server is configured in HTTP mode), do not pass it; an invalid `cert_path`
will lead to errors.

Tracked under:
https://dev.azure.com/ni/DevCentral/_workitems/edit/3961101
and
https://dev.azure.com/ni/DevCentral/_queries/edit/3944027

### Why should this Pull Request be merged?

It will allow customers whose notebooks use this library and break after upgrading to SLS 26Q3, to quickly fix them up by having an Administrator bump the library to the patched version that we'll release once this PR is merged.

### What testing has been done?

Manual testing in a SLS instance. Verified that this snippet
`from nisystemlink.clients.tag import TagManager
tag_manager = TagManager()
tag_manager.open("tagname")`
yields no certificate errors when:
- Web Server is configured in HTTP mode (no certificate exists under Certificates/http-server)
- Web Server is configured in HTTPS mode, with a self-signed certificate (certificate exists).