### PR TITLE
chore: Publish packages to GitHub release corresponding to highest-versioned tag reachable from the current branch

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,10 +93,15 @@ jobs:
           TWINE_USERNAME: ${{secrets.REPOSITORY_USERNAME}}
           TWINE_PASSWORD: ${{secrets.PYPI_PASSWORD}}
       - name: Semantic release - Publish package distributions to GitHub Releases
-        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.      
+        # Only publish if Semantic release built packages under "dist/"; hashFiles returns '' when no files match the given pattern.
         if: hashFiles('dist/*') != ''
         run: |
-          semantic-release publish
+          # Publish packages to the latest GitHub release reachable from the current branch.
+          # This is so that releases from maintenance branches (e.g. "1.6.x") don't upload
+          # packages to the latest release on the repo (default behavior of 'publish' when
+          # no tag is passed), which would likely be one that was published from master.
+          RELEASE_TAG="$(git describe --tags --abbrev=0)"
+          semantic-release publish --tag "$RELEASE_TAG"
         env:
           # To generate a new token use the following guide, providing access to the "repo" scope.
           # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -98,8 +98,9 @@ jobs:
         run: |
           # Publish packages to the latest GitHub release reachable from the current branch.
           # This is so that releases from maintenance branches (e.g. "1.6.x") don't upload
-          # packages to the latest release on the repo (default behavior of 'publish' when
-          # no tag is passed), which would likely be one that was published from master.
+          # packages to the highest-versioned release on the repo (default behavior of
+          # 'publish' when no tag is passed), which would likely be one that was published
+          # from master.
           RELEASE_TAG="$(git describe --tags --abbrev=0)"
           semantic-release publish --tag "$RELEASE_TAG"
         env:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

While releasing a new patch version (1.6.1) from the 1.6.x branch, me and @spanglerco discovered that the Python packages were not published to the 1.6.1 release on GitHub, but instead they were appended to the existing 2.32.1 release (highest-versioned in the repo at the time).

This is caused by the fact that `semantic-release publish` will try to publish to the highest-versioned (not the one marked as 'latest release' on the repo) release available repo-wide, instead of the latest reachable from the current branch.

Therefore, we'll pass a `--tag` parameter to `semantic-release publish`, which will pass the latest tag reachable from the current branch. This will direct `publish` to attach the packages to the release matching that tag.

### Why should this Pull Request be merged?

This fixes the situation where a version is released from a maintenance branch (e.g. 1.6.x), but there exists a previously-released, higher version (this would be the latest released off the `master` branch). Without this fix, the packages will end up being published to the higher version, instead of the one released out of the maintenance branch earlier in the workflow.

### What testing has been done?

Verified locally that `git describe --tags --abbrev=0` properly returns the latest released tag reachable from the currently active branch:
- when run from the `master` branch, it returned the latest v2.32.1
- when run from the `1.6.x` branch, it returned v1.6.1

At the time of writing, these were indeed the latest tags reachable from their respective branches.