### PR TITLE
chore: remove Snyk configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 * @rbell517 @spanglerco @cameronwaterman
 
-/.snyk @ni/security-scanning-owners
 /.wiz @ni/security-scanning-owners

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-exclude: {}
-version: v1.25.1
-ignore: {}
-patch: {}


### PR DESCRIPTION
Removes the `.snyk` configuration file as part of the Snyk -> Wiz migration.

Snyk scanning has been replaced by Wiz, so the repo-level `.snyk` policy /
ignore file is no longer used.

Work item: [AB#3893372](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3893372)