### PR TITLE
feat: Add updatedAt support for orderBy and projection in query specs

### DIFF
--- a/nisystemlink/clients/spec/models/__init__.py
+++ b/nisystemlink/clients/spec/models/__init__.py
@@ -16,6 +16,7 @@ from ._delete_specs_request import DeleteSpecificationsPartialSuccess
 from ._query_specs import (
     QuerySpecificationsRequest,
     PagedSpecifications,
+    SpecificationOrderBy,
     SpecificationProjection,
 )
 from ._specification import (

--- a/nisystemlink/clients/spec/models/_query_specs.py
+++ b/nisystemlink/clients/spec/models/_query_specs.py
@@ -32,6 +32,7 @@ class SpecificationProjection(str, Enum):
     WORKSPACE = "WORKSPACE"
     CREATED_AT = "CREATED_AT"
     CREATED_BY = "CREATED_BY"
+    UPDATED_AT = "UPDATED_AT"
 
 
 class SpecificationOrderBy(Enum):
@@ -39,6 +40,7 @@ class SpecificationOrderBy(Enum):
 
     ID = "ID"
     SPEC_ID = "SPEC_ID"
+    UPDATED_AT = "UPDATED_AT"
 
 
 class QuerySpecificationsRequest(JsonModel):

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -319,7 +319,11 @@ class TestSpec:
     ):
         request = QuerySpecificationsRequest(
             product_ids=[product],
-            projection=[SpecificationProjection.SPEC_ID, SpecificationProjection.NAME],
+            projection=[
+                SpecificationProjection.SPEC_ID,
+                SpecificationProjection.NAME,
+                SpecificationProjection.UPDATED_AT,
+            ],
         )
 
         response = client.query_specs(request)
@@ -330,9 +334,10 @@ class TestSpec:
 
         assert response.specs
         assert len(response.specs) == 3
-        assert len(spec_columns) == 2
+        assert len(spec_columns) == 3
         assert "spec_id" in spec_columns
         assert "name" in spec_columns
+        assert "updated_at" in spec_columns
 
     def test__query_specs__returns_condition_value_type_correctly(
         self, client: SpecClient, create_specs, create_specs_for_query, product
@@ -506,21 +511,4 @@ class TestSpec:
         assert response.specs[0].spec_id == spec_1_id
         assert response.specs[1].spec_id == spec_2_id
 
-    def test__query_specs_with_updated_at_projection__returns_updated_at_field(
-        self, client: SpecClient, create_specs, create_specs_for_query, product
-    ):
-        request = QuerySpecificationsRequest(
-            product_ids=[product],
-            projection=[SpecificationProjection.UPDATED_AT],
-        )
 
-        response = client.query_specs(request)
-        specs = [vars(spec) for spec in response.specs or []]
-        non_none_fields = {
-            key for spec in specs for key, val in spec.items() if val is not None
-        }
-
-        assert response.specs
-        assert len(response.specs) == 3
-        assert "updated_at" in non_none_fields
-        assert len(non_none_fields) == 1

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -412,8 +412,21 @@ class TestSpec:
         assert "condition_unit" in spec_columns
         assert "condition_type" not in spec_columns
 
-    def test__query_specs_order_by_updated_at__returns_in_ascending_order(
-        self, client: SpecClient, create_specs, product
+    @pytest.mark.parametrize(
+        "order_by_descending, expected_first, expected_second",
+        [
+            (False, "spec_2_id", "spec_1_id"),
+            (True, "spec_1_id", "spec_2_id"),
+        ],
+    )
+    def test__query_specs_order_by_updated_at__returns_in_expected_order(
+        self,
+        client: SpecClient,
+        create_specs,
+        product,
+        order_by_descending: bool,
+        expected_first: str,
+        expected_second: str,
     ):
         # Create two specs, then update the first so it has a later updated_at than the second.
         spec_1_id = uuid.uuid1().hex
@@ -458,65 +471,11 @@ class TestSpec:
         request = QuerySpecificationsRequest(
             product_ids=[product],
             order_by=SpecificationOrderBy.UPDATED_AT,
-            order_by_descending=False,
+            order_by_descending=order_by_descending,
         )
         response = client.query_specs(request)
 
+        ids = {"spec_1_id": spec_1_id, "spec_2_id": spec_2_id}
         assert response.specs
-        # spec_2 was not updated, so it has an earlier updated_at — must come first
-        assert response.specs[0].spec_id == spec_2_id
-        assert response.specs[1].spec_id == spec_1_id
-
-    def test__query_specs_order_by_updated_at_descending__returns_in_descending_order(
-        self, client: SpecClient, create_specs, product
-    ):
-        spec_1_id = uuid.uuid1().hex
-        spec_2_id = uuid.uuid1().hex
-        response = create_specs(
-            CreateSpecificationsRequest(
-                specs=[
-                    CreateSpecificationsRequestObject(
-                        product_id=product,
-                        spec_id=spec_1_id,
-                        type=SpecificationType.FUNCTIONAL,
-                    ),
-                    CreateSpecificationsRequestObject(
-                        product_id=product,
-                        spec_id=spec_2_id,
-                        type=SpecificationType.FUNCTIONAL,
-                    ),
-                ]
-            )
-        )
-        spec_1 = next(
-            spec for spec in response.created_specs if spec.spec_id == spec_1_id
-        )
-        update_response = client.update_specs(
-            UpdateSpecificationsRequest(
-                specs=[
-                    UpdateSpecificationsRequestObject(
-                        id=spec_1.id,
-                        product_id=spec_1.product_id,
-                        spec_id=spec_1.spec_id,
-                        type=SpecificationType.PARAMETRIC,
-                        version=spec_1.version,
-                        workspace=spec_1.workspace,
-                    )
-                ]
-            )
-        )
-        assert update_response
-        assert update_response.updated_specs
-        assert len(update_response.updated_specs) == 1
-
-        request = QuerySpecificationsRequest(
-            product_ids=[product],
-            order_by=SpecificationOrderBy.UPDATED_AT,
-            order_by_descending=True,
-        )
-        response = client.query_specs(request)
-
-        assert response.specs
-        # spec_1 was updated last, so it has a later updated_at — must come first
-        assert response.specs[0].spec_id == spec_1_id
-        assert response.specs[1].spec_id == spec_2_id
+        assert response.specs[0].spec_id == ids[expected_first]
+        assert response.specs[1].spec_id == ids[expected_second]

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -408,36 +408,103 @@ class TestSpec:
         assert "condition_type" not in spec_columns
 
     def test__query_specs_order_by_updated_at__returns_in_ascending_order(
-        self, client: SpecClient, create_specs, create_specs_for_query, product
+        self, client: SpecClient, create_specs, product
     ):
+        # Create two specs, then update the first so it has a later updated_at than the second.
+        spec_1_id = uuid.uuid1().hex
+        spec_2_id = uuid.uuid1().hex
+        response = create_specs(
+            CreateSpecificationsRequest(
+                specs=[
+                    CreateSpecificationsRequestObject(
+                        product_id=product,
+                        spec_id=spec_1_id,
+                        type=SpecificationType.FUNCTIONAL,
+                    ),
+                    CreateSpecificationsRequestObject(
+                        product_id=product,
+                        spec_id=spec_2_id,
+                        type=SpecificationType.FUNCTIONAL,
+                    ),
+                ]
+            )
+        )
+        spec_1 = next(s for s in response.created_specs if s.spec_id == spec_1_id)
+        client.update_specs(
+            UpdateSpecificationsRequest(
+                specs=[
+                    UpdateSpecificationsRequestObject(
+                        id=spec_1.id,
+                        product_id=spec_1.product_id,
+                        spec_id=spec_1.spec_id,
+                        type=SpecificationType.PARAMETRIC,
+                        version=spec_1.version,
+                        workspace=spec_1.workspace,
+                    )
+                ]
+            )
+        )
+
         request = QuerySpecificationsRequest(
             product_ids=[product],
             order_by=SpecificationOrderBy.UPDATED_AT,
             order_by_descending=False,
         )
-
         response = client.query_specs(request)
 
         assert response.specs
-        assert len(response.specs) == 3
-        updated_ats = [spec.updated_at for spec in response.specs if spec.updated_at]
-        assert updated_ats == sorted(updated_ats)
+        # spec_2 was not updated, so it has an earlier updated_at — must come first
+        assert response.specs[0].spec_id == spec_2_id
+        assert response.specs[1].spec_id == spec_1_id
 
     def test__query_specs_order_by_updated_at_descending__returns_in_descending_order(
-        self, client: SpecClient, create_specs, create_specs_for_query, product
+        self, client: SpecClient, create_specs, product
     ):
+        spec_1_id = uuid.uuid1().hex
+        spec_2_id = uuid.uuid1().hex
+        response = create_specs(
+            CreateSpecificationsRequest(
+                specs=[
+                    CreateSpecificationsRequestObject(
+                        product_id=product,
+                        spec_id=spec_1_id,
+                        type=SpecificationType.FUNCTIONAL,
+                    ),
+                    CreateSpecificationsRequestObject(
+                        product_id=product,
+                        spec_id=spec_2_id,
+                        type=SpecificationType.FUNCTIONAL,
+                    ),
+                ]
+            )
+        )
+        spec_1 = next(s for s in response.created_specs if s.spec_id == spec_1_id)
+        client.update_specs(
+            UpdateSpecificationsRequest(
+                specs=[
+                    UpdateSpecificationsRequestObject(
+                        id=spec_1.id,
+                        product_id=spec_1.product_id,
+                        spec_id=spec_1.spec_id,
+                        type=SpecificationType.PARAMETRIC,
+                        version=spec_1.version,
+                        workspace=spec_1.workspace,
+                    )
+                ]
+            )
+        )
+
         request = QuerySpecificationsRequest(
             product_ids=[product],
             order_by=SpecificationOrderBy.UPDATED_AT,
             order_by_descending=True,
         )
-
         response = client.query_specs(request)
 
         assert response.specs
-        assert len(response.specs) == 3
-        updated_ats = [spec.updated_at for spec in response.specs if spec.updated_at]
-        assert updated_ats == sorted(updated_ats, reverse=True)
+        # spec_1 was updated last, so it has a later updated_at — must come first
+        assert response.specs[0].spec_id == spec_1_id
+        assert response.specs[1].spec_id == spec_2_id
 
     def test__query_specs_with_updated_at_projection__returns_updated_at_field(
         self, client: SpecClient, create_specs, create_specs_for_query, product

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -437,7 +437,7 @@ class TestSpec:
         spec_1 = next(
             spec for spec in response.created_specs if spec.spec_id == spec_1_id
         )
-        client.update_specs(
+        update_response = client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[
                     UpdateSpecificationsRequestObject(
@@ -451,6 +451,9 @@ class TestSpec:
                 ]
             )
         )
+        assert update_response
+        assert update_response.updated_specs
+        assert len(update_response.updated_specs) == 1
 
         request = QuerySpecificationsRequest(
             product_ids=[product],
@@ -488,7 +491,7 @@ class TestSpec:
         spec_1 = next(
             spec for spec in response.created_specs if spec.spec_id == spec_1_id
         )
-        client.update_specs(
+        update_response = client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[
                     UpdateSpecificationsRequestObject(
@@ -502,6 +505,9 @@ class TestSpec:
                 ]
             )
         )
+        assert update_response
+        assert update_response.updated_specs
+        assert len(update_response.updated_specs) == 1
 
         request = QuerySpecificationsRequest(
             product_ids=[product],

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -434,7 +434,9 @@ class TestSpec:
                 ]
             )
         )
-        spec_1 = next(spec for spec in response.created_specs if spec.spec_id == spec_1_id)
+        spec_1 = next(
+            spec for spec in response.created_specs if spec.spec_id == spec_1_id
+        )
         client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[
@@ -483,7 +485,9 @@ class TestSpec:
                 ]
             )
         )
-        spec_1 = next(spec for spec in response.created_specs if spec.spec_id == spec_1_id)
+        spec_1 = next(
+            spec for spec in response.created_specs if spec.spec_id == spec_1_id
+        )
         client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[
@@ -510,5 +514,3 @@ class TestSpec:
         # spec_1 was updated last, so it has a later updated_at — must come first
         assert response.specs[0].spec_id == spec_1_id
         assert response.specs[1].spec_id == spec_2_id
-
-

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -434,7 +434,7 @@ class TestSpec:
                 ]
             )
         )
-        spec_1 = next(s for s in response.created_specs if s.spec_id == spec_1_id)
+        spec_1 = next(spec for spec in response.created_specs if spec.spec_id == spec_1_id)
         client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[
@@ -483,7 +483,7 @@ class TestSpec:
                 ]
             )
         )
-        spec_1 = next(s for s in response.created_specs if s.spec_id == spec_1_id)
+        spec_1 = next(spec for spec in response.created_specs if spec.spec_id == spec_1_id)
         client.update_specs(
             UpdateSpecificationsRequest(
                 specs=[

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -16,6 +16,7 @@ from nisystemlink.clients.spec.models import (
     NumericConditionValue,
     QuerySpecificationsRequest,
     SpecificationLimit,
+    SpecificationOrderBy,
     SpecificationProjection,
     SpecificationType,
     StringConditionValue,
@@ -405,3 +406,54 @@ class TestSpec:
         assert "condition_name" in spec_columns
         assert "condition_unit" in spec_columns
         assert "condition_type" not in spec_columns
+
+    def test__query_specs_order_by_updated_at__returns_in_ascending_order(
+        self, client: SpecClient, create_specs, create_specs_for_query, product
+    ):
+        request = QuerySpecificationsRequest(
+            product_ids=[product],
+            order_by=SpecificationOrderBy.UPDATED_AT,
+            order_by_descending=False,
+        )
+
+        response = client.query_specs(request)
+
+        assert response.specs
+        assert len(response.specs) == 3
+        updated_ats = [spec.updated_at for spec in response.specs if spec.updated_at]
+        assert updated_ats == sorted(updated_ats)
+
+    def test__query_specs_order_by_updated_at_descending__returns_in_descending_order(
+        self, client: SpecClient, create_specs, create_specs_for_query, product
+    ):
+        request = QuerySpecificationsRequest(
+            product_ids=[product],
+            order_by=SpecificationOrderBy.UPDATED_AT,
+            order_by_descending=True,
+        )
+
+        response = client.query_specs(request)
+
+        assert response.specs
+        assert len(response.specs) == 3
+        updated_ats = [spec.updated_at for spec in response.specs if spec.updated_at]
+        assert updated_ats == sorted(updated_ats, reverse=True)
+
+    def test__query_specs_with_updated_at_projection__returns_updated_at_field(
+        self, client: SpecClient, create_specs, create_specs_for_query, product
+    ):
+        request = QuerySpecificationsRequest(
+            product_ids=[product],
+            projection=[SpecificationProjection.UPDATED_AT],
+        )
+
+        response = client.query_specs(request)
+        specs = [vars(spec) for spec in response.specs or []]
+        non_none_fields = {
+            key for spec in specs for key, val in spec.items() if val is not None
+        }
+
+        assert response.specs
+        assert len(response.specs) == 3
+        assert "updated_at" in non_none_fields
+        assert len(non_none_fields) == 1


### PR DESCRIPTION
## Summary

Adds `UPDATED_AT` as a supported value for `order_by` and `projection` in `QuerySpecificationsRequest`, consistent with the server-side changes made in the Skyline repo.

[Pull Request 1293910](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/1293910): Specification Management | Add updatedAt field to order by options in /query-specs
[Technical Debt 4025900](https://dev.azure.com/ni/DevCentral/_workitems/edit/4025900): Specs Service Python client | Add UpdatedAt support for query specs

## Changes

- **`SpecificationOrderBy`**: Added `UPDATED_AT` enum value, allowing specs to be sorted by last modification time.
- **`SpecificationProjection`**: Added `UPDATED_AT` enum value, allowing `updatedAt` to be requested as a projected field (consistent with `CREATED_AT`).
- **`models/__init__.py`**: Exported `SpecificationOrderBy` so it is importable from `nisystemlink.clients.spec.models`.

## Tests

Added integration tests in `tests/integration/spec/test_spec.py`:
- Ascending `updatedAt` ordering — creates two specs, updates one, and verifies the unmodified spec (older `updated_at`) comes first.
- Descending `updatedAt` ordering — same setup, verifies the updated spec (newer `updated_at`) comes first.
- `UPDATED_AT` projection — added `UPDATED_AT` to the existing `test__query_spec_projection_columns__columns_returned` test alongside `SPEC_ID` and `NAME`, verifying all three fields are returned.
